### PR TITLE
Add Mapping, Xbox One Rumble Selection, and Deadzone Detail View

### DIFF
--- a/360 Driver.xcodeproj/project.pbxproj
+++ b/360 Driver.xcodeproj/project.pbxproj
@@ -101,6 +101,12 @@
 		55FE3CA218D7B77800D69E84 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 55B6372018C108A500CE933D /* CoreFoundation.framework */; };
 		55FE3CAB18D7B78D00D69E84 /* testhaptic.c in Sources */ = {isa = PBXBuildFile; fileRef = 55B6373918C108D200CE933D /* testhaptic.c */; };
 		55FE3CAD18D7B7B600D69E84 /* SDL2.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 55FE3CAC18D7B7B600D69E84 /* SDL2.framework */; };
+		622A73C21A7C339000784C02 /* MyWhole360ControllerMapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 622A73C01A7C339000784C02 /* MyWhole360ControllerMapper.h */; };
+		622A73C31A7C339000784C02 /* MyWhole360ControllerMapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 622A73C11A7C339000784C02 /* MyWhole360ControllerMapper.m */; };
+		622A73C61A7C51D400784C02 /* MyAnalogStick.h in Headers */ = {isa = PBXBuildFile; fileRef = 622A73C41A7C51D400784C02 /* MyAnalogStick.h */; };
+		622A73C71A7C51D400784C02 /* MyAnalogStick.m in Sources */ = {isa = PBXBuildFile; fileRef = 622A73C51A7C51D400784C02 /* MyAnalogStick.m */; };
+		622A73CE1A7C879300784C02 /* BindingTableView.h in Headers */ = {isa = PBXBuildFile; fileRef = 622A73CC1A7C879300784C02 /* BindingTableView.h */; };
+		622A73CF1A7C879300784C02 /* BindingTableView.m in Sources */ = {isa = PBXBuildFile; fileRef = 622A73CD1A7C879300784C02 /* BindingTableView.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -300,6 +306,12 @@
 		55E1C62B1970921E00EC9DD8 /* Readme.rtf */ = {isa = PBXFileReference; lastKnownFileType = text.rtf; path = Readme.rtf; sourceTree = SOURCE_ROOT; };
 		55FE3CA118D7B77800D69E84 /* testhaptic */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = testhaptic; sourceTree = BUILT_PRODUCTS_DIR; };
 		55FE3CAC18D7B7B600D69E84 /* SDL2.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SDL2.framework; path = /Library/Frameworks/SDL2.framework; sourceTree = "<absolute>"; };
+		622A73C01A7C339000784C02 /* MyWhole360ControllerMapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MyWhole360ControllerMapper.h; sourceTree = "<group>"; };
+		622A73C11A7C339000784C02 /* MyWhole360ControllerMapper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MyWhole360ControllerMapper.m; sourceTree = "<group>"; };
+		622A73C41A7C51D400784C02 /* MyAnalogStick.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MyAnalogStick.h; path = "../../../../../Downloads/360Controller-0.14-unofficial/Pref360Control/MyAnalogStick.h"; sourceTree = "<group>"; };
+		622A73C51A7C51D400784C02 /* MyAnalogStick.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MyAnalogStick.m; path = "../../../../../Downloads/360Controller-0.14-unofficial/Pref360Control/MyAnalogStick.m"; sourceTree = "<group>"; };
+		622A73CC1A7C879300784C02 /* BindingTableView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BindingTableView.h; sourceTree = "<group>"; };
+		622A73CD1A7C879300784C02 /* BindingTableView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BindingTableView.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -595,10 +607,16 @@
 				55B6379D18C10C0C00CE933D /* DeviceLister.m */,
 				3FE789A21A701FE200FF4065 /* MyWhole360Controller.h */,
 				3FE789A31A701FE200FF4065 /* MyWhole360Controller.m */,
+				622A73C01A7C339000784C02 /* MyWhole360ControllerMapper.h */,
+				622A73C11A7C339000784C02 /* MyWhole360ControllerMapper.m */,
+				622A73CC1A7C879300784C02 /* BindingTableView.h */,
+				622A73CD1A7C879300784C02 /* BindingTableView.m */,
 				3FE789A61A70281200FF4065 /* MyBatteryMonitor.h */,
 				3FE789A71A70281200FF4065 /* MyBatteryMonitor.m */,
 				3FE789AA1A70288F00FF4065 /* MyDeadZoneViewer.h */,
 				3FE789AB1A70288F00FF4065 /* MyDeadZoneViewer.m */,
+				622A73C41A7C51D400784C02 /* MyAnalogStick.h */,
+				622A73C51A7C51D400784C02 /* MyAnalogStick.m */,
 				3FE789AE1A70331C00FF4065 /* MyTrigger.h */,
 				3FE789AF1A70331C00FF4065 /* MyTrigger.m */,
 				55B637A818C10C0C00CE933D /* Pref360ControlPref.h */,
@@ -673,9 +691,12 @@
 				3FE789AC1A70288F00FF4065 /* MyDeadZoneViewer.h in Headers */,
 				3FE789B01A70331C00FF4065 /* MyTrigger.h in Headers */,
 				3FE789A41A701FE200FF4065 /* MyWhole360Controller.h in Headers */,
+				622A73C61A7C51D400784C02 /* MyAnalogStick.h in Headers */,
+				622A73C21A7C339000784C02 /* MyWhole360ControllerMapper.h in Headers */,
 				55B637AA18C10C0C00CE933D /* DeviceItem.h in Headers */,
 				55B637AC18C10C0C00CE933D /* DeviceLister.h in Headers */,
 				55B637B818C10C0C00CE933D /* Pref360ControlPref.h in Headers */,
+				622A73CE1A7C879300784C02 /* BindingTableView.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -984,14 +1005,17 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				622A73C71A7C51D400784C02 /* MyAnalogStick.m in Sources */,
 				55B637AD18C10C0C00CE933D /* DeviceLister.m in Sources */,
 				3FE789A51A701FE200FF4065 /* MyWhole360Controller.m in Sources */,
 				3FE789AD1A70288F00FF4065 /* MyDeadZoneViewer.m in Sources */,
 				3FE789A11A701F3400FF4065 /* Pref360StyleKit.m in Sources */,
 				55B637B918C10C0C00CE933D /* Pref360ControlPref.m in Sources */,
 				3FE789A91A70281200FF4065 /* MyBatteryMonitor.m in Sources */,
+				622A73CF1A7C879300784C02 /* BindingTableView.m in Sources */,
 				55B637AB18C10C0C00CE933D /* DeviceItem.m in Sources */,
 				55B637DD18C10CCC00CE933D /* ControlPrefs.m in Sources */,
+				622A73C31A7C339000784C02 /* MyWhole360ControllerMapper.m in Sources */,
 				3FE789B11A70331C00FF4065 /* MyTrigger.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1342,6 +1366,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = 360Control;
+				DEPLOYMENT_LOCATION = NO;
+				DSTROOT = /;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = Pref360Control/Pref360Control_Prefix.pch;
 				HEADER_SEARCH_PATHS = (
@@ -1360,6 +1386,8 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = 360Control;
 				DEAD_CODE_STRIPPING = YES;
+				DEPLOYMENT_LOCATION = NO;
+				DSTROOT = /;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = Pref360Control/Pref360Control_Prefix.pch;
 				HEADER_SEARCH_PATHS = (

--- a/360Controller/Controller.h
+++ b/360Controller/Controller.h
@@ -54,6 +54,8 @@ public:
     virtual OSNumber* newVendorIDNumber() const;
 	
     virtual OSNumber* newLocationIDNumber() const;
+    
+    virtual void remapButtons(void *buffer);
 };
 
 

--- a/360Controller/Info.plist
+++ b/360Controller/Info.plist
@@ -951,6 +951,26 @@
 			<key>idVendor</key>
 			<integer>9414</integer>
 		</dict>
+		<key>PowerAMiniXboxOne</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>com.mice.driver.Xbox360Controller</string>
+			<key>IOCFPlugInTypes</key>
+			<dict>
+				<key>F4545CE5-BF5B-11D6-A4BB-0003933E3E3E</key>
+				<string>360Controller.kext/Contents/PlugIns/Feedback360.plugin</string>
+			</dict>
+			<key>IOClass</key>
+			<string>Xbox360Peripheral</string>
+			<key>IOKitDebug</key>
+			<integer>65535</integer>
+			<key>IOProviderClass</key>
+			<string>IOUSBDevice</string>
+			<key>idProduct</key>
+			<integer>21530</integer>
+			<key>idVendor</key>
+			<integer>9414</integer>
+		</dict>
 		<key>RAPEXSE</key>
 		<dict>
 			<key>CFBundleIdentifier</key>
@@ -1211,26 +1231,26 @@
 			<key>idVendor</key>
 			<integer>1118</integer>
 		</dict>
- 		<key>RockCandyGamepadforXboxOne</key>
- 		<dict>
- 			<key>CFBundleIdentifier</key>
- 			<string>com.mice.driver.Xbox360Controller</string>
- 			<key>IOCFPlugInTypes</key>
- 			<dict>
- 				<key>F4545CE5-BF5B-11D6-A4BB-0003933E3E3E</key>
- 				<string>360Controller.kext/Contents/PlugIns/Feedback360.plugin</string>
- 			</dict>
- 			<key>IOClass</key>
- 			<string>Xbox360Peripheral</string>
- 			<key>IOKitDebug</key>
- 			<integer>65535</integer>
- 			<key>IOProviderClass</key>
- 			<string>IOUSBDevice</string>
- 			<key>idProduct</key>
- 			<integer>326</integer>
- 			<key>idVendor</key>
- 			<integer>3695</integer>
- 		</dict>
+		<key>RockCandyGamepadforXboxOne</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>com.mice.driver.Xbox360Controller</string>
+			<key>IOCFPlugInTypes</key>
+			<dict>
+				<key>F4545CE5-BF5B-11D6-A4BB-0003933E3E3E</key>
+				<string>360Controller.kext/Contents/PlugIns/Feedback360.plugin</string>
+			</dict>
+			<key>IOClass</key>
+			<string>Xbox360Peripheral</string>
+			<key>IOKitDebug</key>
+			<integer>65535</integer>
+			<key>IOProviderClass</key>
+			<string>IOUSBDevice</string>
+			<key>idProduct</key>
+			<integer>326</integer>
+			<key>idVendor</key>
+			<integer>3695</integer>
+		</dict>
 		<key>SF4StickSE</key>
 		<dict>
 			<key>CFBundleIdentifier</key>

--- a/360Controller/_60Controller.cpp
+++ b/360Controller/_60Controller.cpp
@@ -247,7 +247,40 @@ void Xbox360Peripheral::readSettings(void)
     if (value != NULL) relativeLeft = value->getValue();
     value = OSDynamicCast(OSBoolean, dataDictionary->getObject("RelativeRight"));
     if (value != NULL) relativeRight=value->getValue();
-    
+//    number = OSDynamicCast(OSNumber, dataDictionary->getObject("ControllerType")); // No use currently.
+    number = OSDynamicCast(OSNumber, dataDictionary->getObject("XoneRumbleType"));
+    if (number != NULL) xoneRumbleType = number->unsigned8BitValue();
+    number = OSDynamicCast(OSNumber, dataDictionary->getObject("BindingUp"));
+    if (number != NULL) mapping[0] = number->unsigned32BitValue();
+    number = OSDynamicCast(OSNumber, dataDictionary->getObject("BindingDown"));
+    if (number != NULL) mapping[1] = number->unsigned32BitValue();
+    number = OSDynamicCast(OSNumber, dataDictionary->getObject("BindingLeft"));
+    if (number != NULL) mapping[2] = number->unsigned32BitValue();
+    number = OSDynamicCast(OSNumber, dataDictionary->getObject("BindingRight"));
+    if (number != NULL) mapping[3] = number->unsigned32BitValue();
+    number = OSDynamicCast(OSNumber, dataDictionary->getObject("BindingStart"));
+    if (number != NULL) mapping[4] = number->unsigned32BitValue();
+    number = OSDynamicCast(OSNumber, dataDictionary->getObject("BindingBack"));
+    if (number != NULL) mapping[5] = number->unsigned32BitValue();
+    number = OSDynamicCast(OSNumber, dataDictionary->getObject("BindingLSC"));
+    if (number != NULL) mapping[6] = number->unsigned32BitValue();
+    number = OSDynamicCast(OSNumber, dataDictionary->getObject("BindingRSC"));
+    if (number != NULL) mapping[7] = number->unsigned32BitValue();
+    number = OSDynamicCast(OSNumber, dataDictionary->getObject("BindingLB"));
+    if (number != NULL) mapping[8] = number->unsigned32BitValue();
+    number = OSDynamicCast(OSNumber, dataDictionary->getObject("BindingRB"));
+    if (number != NULL) mapping[9] = number->unsigned32BitValue();
+    number = OSDynamicCast(OSNumber, dataDictionary->getObject("BindingGuide"));
+    if (number != NULL) mapping[10] = number->unsigned32BitValue();
+    number = OSDynamicCast(OSNumber, dataDictionary->getObject("BindingA"));
+    if (number != NULL) mapping[11] = number->unsigned32BitValue();
+    number = OSDynamicCast(OSNumber, dataDictionary->getObject("BindingB"));
+    if (number != NULL) mapping[12] = number->unsigned32BitValue();
+    number = OSDynamicCast(OSNumber, dataDictionary->getObject("BindingX"));
+    if (number != NULL) mapping[13] = number->unsigned32BitValue();
+    number = OSDynamicCast(OSNumber, dataDictionary->getObject("BindingY"));
+    if (number != NULL) mapping[14] = number->unsigned32BitValue();
+
 #if 0
     IOLog("Xbox360Peripheral preferences loaded:\n  invertLeft X: %s, Y: %s\n   invertRight X: %s, Y:%s\n  deadzone Left: %d, Right: %d\n\n",
             invertLeftX?"True":"False",invertLeftY?"True":"False",
@@ -277,6 +310,17 @@ bool Xbox360Peripheral::init(OSDictionary *propTable)
     invertRightX=invertRightY=false;
     deadzoneLeft=deadzoneRight=0;
     relativeLeft=relativeRight=false;
+    // Controller Specific
+    xoneRumbleType = 0;
+    // Bindings
+    for (int i = 0; i < 11; i++)
+    {
+        mapping[i] = i;
+    }
+    for (int i = 12; i < 16; i++)
+    {
+        mapping[i-1] = i;
+    }
     // Done
     return res;
 }
@@ -801,7 +845,10 @@ IOReturn Xbox360Peripheral::setProperties(OSObject *properties)
     OSDictionary *dictionary;
     
     dictionary=OSDynamicCast(OSDictionary,properties);
+    
     if(dictionary!=NULL) {
+        IOLog("CONTROLLER TYPE - DRIVER: %d\n", controllerType);
+        dictionary->setObject(OSString::withCString("ControllerType"), OSNumber::withNumber(controllerType, 8));
         setProperty(kDriverSettingKey,dictionary);
         readSettings();
         return kIOReturnSuccess;

--- a/360Controller/_60Controller.h
+++ b/360Controller/_60Controller.h
@@ -73,9 +73,9 @@ protected:
 	} TIMER_STATE;
     
     typedef enum CONTROLLER_TYPE {
-        Xbox360,
-        XboxOriginal,
-        XboxOne
+        Xbox360 = 0,
+        XboxOriginal = 1,
+        XboxOne = 2
     } CONTROLLER_TYPE;
 	
     IOUSBDevice *device;
@@ -104,8 +104,13 @@ protected:
     bool invertRightX,invertRightY;
     short deadzoneLeft,deadzoneRight;
     bool relativeLeft,relativeRight;
-
+    
 public:
+    // Controller specific
+    UInt8 xoneRumbleType;
+
+    UInt8 mapping[15];
+    
     // this is from the IORegistryEntry - no provider yet
     virtual bool init(OSDictionary *propTable);
     virtual void free(void);

--- a/Pref360Control/BindingTableView.h
+++ b/Pref360Control/BindingTableView.h
@@ -1,0 +1,13 @@
+//
+//  BindingTableView.h
+//  360 Driver
+//
+//  Created by Drew Mills on 1/30/15.
+//  Copyright (c) 2015 GitHub. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface BindingTableView : NSObject
+
+@end

--- a/Pref360Control/BindingTableView.h
+++ b/Pref360Control/BindingTableView.h
@@ -3,11 +3,17 @@
 //  360 Driver
 //
 //  Created by Drew Mills on 1/30/15.
-//  Copyright (c) 2015 GitHub. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+#import <Cocoa/Cocoa.h>
 
-@interface BindingTableView : NSObject
+@interface BindingTableView : NSObject <NSTableViewDelegate, NSTableViewDataSource>
+
+@property NSArray *buttonArr;
+
++ (NSTableView *)tableView;
+
+- (NSInteger)numberOfRowsInTableView:(NSTableView *)tableView;
+- (id)tableView:(NSTableView *)aTableView objectValueForTableColumn:(NSTableColumn *)aTableColumn row:(NSInteger)rowIndex;
 
 @end

--- a/Pref360Control/BindingTableView.m
+++ b/Pref360Control/BindingTableView.m
@@ -3,11 +3,34 @@
 //  360 Driver
 //
 //  Created by Drew Mills on 1/30/15.
-//  Copyright (c) 2015 GitHub. All rights reserved.
 //
 
 #import "BindingTableView.h"
+#import "MyWhole360ControllerMapper.h"
 
 @implementation BindingTableView
+
+static NSTableView *tblView;
+
++ (NSTableView *)tableView {
+    return tblView;
+}
+
+- (void)awakeFromNib {
+    _buttonArr = @[@"Up", @"Down", @"Left", @"Right", @"Start", @"Back", @"LS Click", @"RS Click", @"LB", @"RB", @"Guide", @"A", @"B", @"X", @"Y"];
+}
+
+- (NSInteger)numberOfRowsInTableView:(NSTableView *)tableView {
+    tblView = tableView;
+    return [_buttonArr count];
+}
+
+- (id)tableView:(NSTableView *)aTableView objectValueForTableColumn:(NSTableColumn *)aTableColumn row:(NSInteger)rowIndex {
+    if ([[aTableColumn identifier] isEqualToString:@"input"]) {
+        return [NSNumber numberWithInt:[MyWhole360ControllerMapper mapping][rowIndex]];
+    }
+    else
+        return _buttonArr[rowIndex];
+}
 
 @end

--- a/Pref360Control/BindingTableView.m
+++ b/Pref360Control/BindingTableView.m
@@ -1,0 +1,13 @@
+//
+//  BindingTableView.m
+//  360 Driver
+//
+//  Created by Drew Mills on 1/30/15.
+//  Copyright (c) 2015 GitHub. All rights reserved.
+//
+
+#import "BindingTableView.h"
+
+@implementation BindingTableView
+
+@end

--- a/Pref360Control/MyWhole360ControllerMapper.h
+++ b/Pref360Control/MyWhole360ControllerMapper.h
@@ -6,8 +6,16 @@
 //  Copyright (c) 2015 GitHub. All rights reserved.
 //
 
-#import <Foundation/Foundation.h>
+#import <Cocoa/Cocoa.h>
+#import "MyWhole360Controller.h"
+#import "Pref360ControlPref.h"
 
-@interface MyWhole360ControllerMapper : NSObject
+@interface MyWhole360ControllerMapper : MyWhole360Controller
+
+@property BOOL isMapping;
+
+- (void)runMapperWithButton:(NSButton *)button  andOwner:(Pref360ControlPref *)pref;
+- (void)buttonPressedAtIndex:(int)index;
++ (UInt8 *)mapping;
 
 @end

--- a/Pref360Control/MyWhole360ControllerMapper.h
+++ b/Pref360Control/MyWhole360ControllerMapper.h
@@ -1,0 +1,13 @@
+//
+//  MyWhole360ControllerMapper.h
+//  360 Driver
+//
+//  Created by Drew Mills on 1/30/15.
+//  Copyright (c) 2015 GitHub. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface MyWhole360ControllerMapper : NSObject
+
+@end

--- a/Pref360Control/MyWhole360ControllerMapper.m
+++ b/Pref360Control/MyWhole360ControllerMapper.m
@@ -3,11 +3,174 @@
 //  360 Driver
 //
 //  Created by Drew Mills on 1/30/15.
-//  Copyright (c) 2015 GitHub. All rights reserved.
 //
 
+#import "MyWhole360Controller.h"
 #import "MyWhole360ControllerMapper.h"
+#import "Pref360StyleKit.h"
+#import "BindingTableView.h"
 
 @implementation MyWhole360ControllerMapper
+{
+    int currentMappingIndex;
+    NSButton *remappingButton;
+    Pref360ControlPref *pref;
+}
+
+static UInt8 mapping[15];
+
++ (UInt8 *)mapping
+{
+    return mapping;
+}
+
+- (void)runMapperWithButton:(NSButton *)button andOwner:(Pref360ControlPref *)prefPref {
+    pref = prefPref;
+    remappingButton = button;
+//    [self resetMapping];
+//    [pref changeSetting:nil];
+    currentMappingIndex = 0;
+    _isMapping = YES;
+    [self setUpPressed:YES];
+}
+
+- (int)realignButtonToByte:(int)index {
+    if (index == 0) return 12;
+    if (index == 1) return 13;
+    if (index == 2) return 14;
+    if (index == 3) return 15;
+    if (index == 4) return 8;
+    if (index == 5) return 9;
+    if (index == 6) return 6;
+    if (index == 7) return 7;
+    if (index == 8) return 4;
+    if (index == 9) return 5;
+    if (index == 10) return 10;
+    if (index == 11) return 0;
+    if (index == 12) return 1;
+    if (index == 13) return 2;
+    if (index == 14) return 3;
+    return -1; // Should Never Happen
+}
+
+- (void)buttonPressedAtIndex:(int)index {
+    mapping[currentMappingIndex] = [self realignButtonToByte:index];
+    currentMappingIndex++;
+    [self setButtonAtIndex:currentMappingIndex];
+    if (currentMappingIndex == 15) {
+        _isMapping = NO;
+        currentMappingIndex = 0;
+        [remappingButton setState:NSOffState];
+        [[BindingTableView tableView] reloadData];
+        [pref changeSetting:nil];
+    }
+}
+
+- (void)setButtonAtIndex:(int)index {
+    switch (index) {
+        case 1:
+            [self setUpPressed:NO];
+            [self setDownPressed:YES];
+            break;
+            
+        case 2:
+            [self setDownPressed:NO];
+            [self setLeftPressed:YES];
+            break;
+            
+        case 3:
+            [self setLeftPressed:NO];
+            [self setRightPressed:YES];
+            break;
+            
+        case 4:
+            [self setRightPressed:NO];
+            [self setStartPressed:YES];
+            break;
+            
+        case 5:
+            [self setStartPressed:NO];
+            [self setBackPressed:YES];
+            break;
+            
+        case 6:
+            [self setBackPressed:NO];
+            [self setLeftStickPressed:YES];
+            break;
+            
+        case 7:
+            [self setLeftStickPressed:NO];
+            [self setRightStickPressed:YES];
+            break;
+            
+        case 8:
+            [self setRightStickPressed:NO];
+            [self setLbPressed:YES];
+            break;
+            
+        case 9:
+            [self setLbPressed:NO];
+            [self setRbPressed:YES];
+            break;
+            
+        case 10:
+            [self setRbPressed:NO];
+            [self setHomePressed:YES];
+            break;
+            
+        case 11:
+            [self setHomePressed:NO];
+            [self setAPressed:YES];
+            break;
+            
+        case 12:
+            [self setAPressed:NO];
+            [self setBPressed:YES];
+            break;
+            
+        case 13:
+            [self setBPressed:NO];
+            [self setXPressed:YES];
+            break;
+            
+        case 14:
+            [self setXPressed:NO];
+            [self setYPressed:YES];
+            break;
+            
+        case 15:
+            [self setYPressed:NO];
+            break;
+            
+        default:
+            break;
+    }
+}
+
+- (void)resetMapping {
+    for (int i = 0; i < 15; i++) {
+        mapping[i] = i;
+    }
+    for (int i = 12; i < 16; i++) {
+        mapping[i-1] = i;
+    }
+}
+
+- (void)reset {
+    [super reset];
+    _isMapping = NO;
+    [self resetMapping];
+    [remappingButton setState:NSOffState];
+    [pref changeSetting:nil];
+    [[BindingTableView tableView] reloadData];
+//    [pref changeSetting:nil];
+}
+
+- (void)awakeFromNib {
+    [super awakeFromNib];
+    _isMapping = NO;
+    [self resetMapping];
+    [[BindingTableView tableView] reloadData];
+}
 
 @end

--- a/Pref360Control/MyWhole360ControllerMapper.m
+++ b/Pref360Control/MyWhole360ControllerMapper.m
@@ -1,0 +1,13 @@
+//
+//  MyWhole360ControllerMapper.m
+//  360 Driver
+//
+//  Created by Drew Mills on 1/30/15.
+//  Copyright (c) 2015 GitHub. All rights reserved.
+//
+
+#import "MyWhole360ControllerMapper.h"
+
+@implementation MyWhole360ControllerMapper
+
+@end

--- a/Pref360Control/Pref360ControlPref.h
+++ b/Pref360Control/Pref360ControlPref.h
@@ -30,12 +30,20 @@
 #include <ForceFeedback/ForceFeedback.h>
 
 @class MyWhole360Controller;
+@class MyWhole360ControllerMapper;
 @class MyTrigger;
 @class MyBatteryMonitor;
 @class MyDeadZoneViewer;
+@class MyAnalogStick;
 @class DeviceLister;
 
-@interface Pref360ControlPref : NSPreferencePane 
+typedef NS_ENUM(NSUInteger, ControllerType) {
+    Xbox360Controller = 0,
+    XboxOriginalController = 1,
+    XboxOneController = 2
+} controllerType;
+
+@interface Pref360ControlPref : NSPreferencePane
 // Window components
 @property (weak) IBOutlet NSPopUpButton *deviceList;
 @property (weak) IBOutlet NSButton *leftLinked;
@@ -55,7 +63,28 @@
 @property (weak) IBOutlet MyDeadZoneViewer *leftDeadZone;
 @property (weak) IBOutlet MyDeadZoneViewer *rightDeadZone;
 @property (strong) IBOutlet NSPopover *aboutPopover;
+@property (weak) IBOutlet NSPopUpButton *xoneRumbleOptions;
 
+// Binding Tab
+@property (weak) IBOutlet NSPopUpButton *deviceListBinding;
+@property (weak) IBOutlet MyWhole360ControllerMapper *wholeControllerMapper;
+@property (weak) IBOutlet NSTabView *tabView;
+@property (weak) IBOutlet NSButton *remappingButton;
+@property (weak) IBOutlet NSTableView *mappingTable;
+@property (weak) IBOutlet NSButton *remappingResetButton;
+
+// Deadzones Tab
+@property (weak) IBOutlet NSPopUpButton *deviceListDeadzones;
+@property (weak) IBOutlet MyAnalogStick *leftStickAnalog;
+@property (weak) IBOutlet MyAnalogStick *rightStickAnalog;
+@property (weak) IBOutlet NSButton *leftLinkedAlt;
+@property (weak) IBOutlet NSSlider *leftStickDeadzoneAlt;
+@property (weak) IBOutlet NSButton *leftStickInvertXAlt;
+@property (weak) IBOutlet NSButton *leftStickInvertYAlt;
+@property (weak) IBOutlet NSButton *rightLinkedAlt;
+@property (weak) IBOutlet NSSlider *rightStickDeadzoneAlt;
+@property (weak) IBOutlet NSButton *rightStickInvertXAlt;
+@property (weak) IBOutlet NSButton *rightStickInvertYAlt;
 
 // Internal info
 @property (readonly) mach_port_t masterPort;

--- a/Pref360Control/Pref360ControlPref.m
+++ b/Pref360Control/Pref360ControlPref.m
@@ -27,9 +27,11 @@
 #import "ControlPrefs.h"
 #import "DeviceLister.h"
 #import "MyWhole360Controller.h"
+#import "MyWhole360ControllerMapper.h"
 #import "MyTrigger.h"
 #import "MyDeadZoneViewer.h"
 #import "MyBatteryMonitor.h"
+#import "MyAnalogStick.h"
 
 #define NO_ITEMS @"No devices found"
 
@@ -84,6 +86,8 @@ static void callbackHandleDevice(void *param,io_iterator_t iterator)
 
 -(void)awakeFromNib {
     [_aboutPopover setAppearance:NSPopoverAppearanceHUD];
+    [_xoneRumbleOptions removeAllItems];
+    [_xoneRumbleOptions addItemsWithTitles:@[@"Default", @"Triggers Only", @"Both"]];
 }
 
 // Set the pattern on the LEDs
@@ -165,33 +169,43 @@ static void callbackHandleDevice(void *param,io_iterator_t iterator)
 // Update axis GUI component
 - (void)axisChanged:(int)index newValue:(int)value
 {
+    NSInteger tabIndex = [_tabView indexOfTabViewItem:[_tabView selectedTabViewItem]];
+    
     switch(index) {
         case 0:
             [_wholeController setLeftStickXPos:value];
+            [_leftStickAnalog setPositionX:value];
             break;
             
         case 1:
             [_wholeController setLeftStickYPos:value];
+            [_leftStickAnalog setPositionY:value];
             break;
             
         case 2:
             [_wholeController setRightStickXPos:value];
+            [_rightStickAnalog setPositionX:value];
             break;
             
         case 3:
             [_wholeController setRightStickYPos:value];
+            [_rightStickAnalog setPositionY:value];
             break;
             
         case 4:
-            [_leftTrigger setVal:value];
-            largeMotor=value;
-            [self testMotorsLarge:largeMotor small:smallMotor];
+            if (tabIndex == 0) { // Controller Test
+                [_leftTrigger setVal:value];
+                largeMotor=value;
+                [self testMotorsLarge:largeMotor small:smallMotor];
+            }
             break;
             
         case 5:
-            [_rightTrigger setVal:value];
-            smallMotor=value;
-            [self testMotorsLarge:largeMotor small:smallMotor];
+            if (tabIndex == 0) {
+                [_rightTrigger setVal:value];
+                smallMotor=value;
+                [self testMotorsLarge:largeMotor small:smallMotor];
+            }
             break;
             
         default:
@@ -203,70 +217,80 @@ static void callbackHandleDevice(void *param,io_iterator_t iterator)
 - (void)buttonChanged:(int)index newValue:(int)value
 {
     BOOL b = (value != 0);
+    NSInteger tabIndex = [_tabView indexOfTabViewItem:[_tabView selectedTabViewItem]];
     
-    switch (index) {
-        case 0:
-            [_wholeController setAPressed:b];
-            break;
-            
-        case 1:
-            [_wholeController setBPressed:b];
-            break;
-            
-        case 2:
-            [_wholeController setXPressed:b];
-            break;
-            
-        case 3:
-            [_wholeController setYPressed:b];
-            break;
-            
-        case 4:
-            [_wholeController setLbPressed:b];
-            break;
-            
-        case 5:
-            [_wholeController setRbPressed:b];
-            break;
-            
-        case 6:
-            [_wholeController setLeftStickPressed:b];
-            break;
-            
-        case 7:
-            [_wholeController setRightStickPressed:b];
-            break;
-            
-        case 8:
-            [_wholeController setStartPressed:b];
-            break;
-            
-        case 9:
-            [_wholeController setBackPressed:b];
-            break;
-            
-        case 10:
-            [_wholeController setHomePressed:b];
-            break;
-            
-        case 11:
-            [_wholeController setUpPressed:b];
-            break;
-            
-        case 12:
-            [_wholeController setDownPressed:b];
-            break;
-            
-        case 13:
-            [_wholeController setLeftPressed:b];
-            break;
-            
-        case 14:
-            [_wholeController setRightPressed:b];
-            break;
-            
-        default:
-            break;
+    if (tabIndex == 0) { // Controller Test
+        switch (index) {
+            case 0:
+                [_wholeController setAPressed:b];
+                break;
+                
+            case 1:
+                [_wholeController setBPressed:b];
+                break;
+                
+            case 2:
+                [_wholeController setXPressed:b];
+                break;
+                
+            case 3:
+                [_wholeController setYPressed:b];
+                break;
+                
+            case 4:
+                [_wholeController setLbPressed:b];
+                break;
+                
+            case 5:
+                [_wholeController setRbPressed:b];
+                break;
+                
+            case 6:
+                [_wholeController setLeftStickPressed:b];
+                break;
+                
+            case 7:
+                [_wholeController setRightStickPressed:b];
+                break;
+                
+            case 8:
+                [_wholeController setStartPressed:b];
+                break;
+                
+            case 9:
+                [_wholeController setBackPressed:b];
+                break;
+                
+            case 10:
+                [_wholeController setHomePressed:b];
+                break;
+                
+            case 11:
+                [_wholeController setUpPressed:b];
+                break;
+                
+            case 12:
+                [_wholeController setDownPressed:b];
+                break;
+                
+            case 13:
+                [_wholeController setLeftPressed:b];
+                break;
+                
+            case 14:
+                [_wholeController setRightPressed:b];
+                break;
+                
+            default:
+                break;
+        }
+    }
+    else if (tabIndex == 1) { // Tweaks
+        if ([_wholeControllerMapper isMapping]) {
+            if (b == YES) {
+                [_wholeControllerMapper buttonPressedAtIndex:index];
+            }
+        }
     }
 }
 
@@ -306,13 +330,28 @@ static void callbackHandleDevice(void *param,io_iterator_t iterator)
 - (void)inputEnable:(BOOL)enable
 {
     [_leftStickDeadzone setEnabled:enable];
+    [_leftStickDeadzoneAlt setEnabled:enable];
     [_leftStickInvertX setEnabled:enable];
+    [_leftStickInvertXAlt setEnabled:enable];
     [_leftStickInvertY setEnabled:enable];
+    [_leftStickInvertYAlt setEnabled:enable];
     [_leftLinked setEnabled:enable];
+    [_leftLinkedAlt setEnabled:enable];
     [_rightStickDeadzone setEnabled:enable];
+    [_rightStickDeadzoneAlt setEnabled:enable];
     [_rightStickInvertX setEnabled:enable];
+    [_rightStickInvertXAlt setEnabled:enable];
     [_rightStickInvertY setEnabled:enable];
+    [_rightStickInvertYAlt setEnabled:enable];
     [_rightLinked setEnabled:enable];
+    [_rightLinkedAlt setEnabled:enable];
+    if (enable) { // If trying to enable, make sure its an Xbox One Controller
+//        if (controllerType == XboxOneController) // Ignore until settings are fixed (Issue #67
+            [_xoneRumbleOptions setEnabled:enable];
+    }
+    else { // Always disable
+        [_xoneRumbleOptions setEnabled:enable];
+    }
 }
 
 // Reset GUI components
@@ -322,16 +361,26 @@ static void callbackHandleDevice(void *param,io_iterator_t iterator)
     [_rightTrigger setVal:0];
     [_wholeController reset];
     [_leftDeadZone setVal:0];
+    [_leftStickAnalog setDeadzone:0];
     [_leftDeadZone setLinked:NO];
+    [_leftStickAnalog setLinked:NO];
     [_rightDeadZone setVal:0];
+    [_rightStickAnalog setDeadzone:0];
     [_rightDeadZone setLinked:NO];
+    [_rightStickAnalog setLinked:NO];
     // Reset inputs
     [_leftStickDeadzone setIntValue:0];
+    [_leftStickDeadzoneAlt setIntValue:0];
     [_leftStickInvertX setState:NSOffState];
+    [_leftStickInvertXAlt setState:NSOffState];
     [_leftStickInvertY setState:NSOffState];
+    [_leftStickInvertYAlt setState:NSOffState];
     [_rightStickDeadzone setIntValue:0];
+    [_rightStickDeadzoneAlt setIntValue:0];
     [_rightStickInvertX setState:NSOffState];
+    [_rightStickInvertXAlt setState:NSOffState];
     [_rightStickInvertY setState:NSOffState];
+    [_rightStickInvertYAlt setState:NSOffState];
     // Disable inputs
     [self inputEnable:NO];
     [_powerOff setHidden:YES];
@@ -500,42 +549,124 @@ static void callbackHandleDevice(void *param,io_iterator_t iterator)
             
             if(CFDictionaryGetValueIfPresent(dict,CFSTR("InvertLeftX"),(void*)&boolValue)) {
                 [_leftStickInvertX setState:CFBooleanGetValue(boolValue)?NSOnState:NSOffState];
-            } else NSLog(@"No value for InvertLeftX");
+                [_leftStickInvertXAlt setState:CFBooleanGetValue(boolValue)?NSOnState:NSOffState];
+            } else NSLog(@"No value for InvertLeftX\n");
             if(CFDictionaryGetValueIfPresent(dict,CFSTR("InvertLeftY"),(void*)&boolValue)) {
                 [_leftStickInvertY setState:CFBooleanGetValue(boolValue)?NSOnState:NSOffState];
-            } else NSLog(@"No value for InvertLeftY");
+                [_leftStickInvertYAlt setState:CFBooleanGetValue(boolValue)?NSOnState:NSOffState];
+            } else NSLog(@"No value for InvertLeftY\n");
             if(CFDictionaryGetValueIfPresent(dict,CFSTR("RelativeLeft"),(void*)&boolValue)) {
                 BOOL enable=CFBooleanGetValue(boolValue);
                 [_leftLinked setState:enable?NSOnState:NSOffState];
+                [_leftLinkedAlt setState:enable?NSOnState:NSOffState];
                 [_leftDeadZone setLinked:enable];
-            } else NSLog(@"No value for RelativeLeft");
+                [_leftStickAnalog setLinked:enable];
+            } else NSLog(@"No value for RelativeLeft\n");
             if(CFDictionaryGetValueIfPresent(dict,CFSTR("DeadzoneLeft"),(void*)&intValue)) {
                 UInt16 i;
                 
                 CFNumberGetValue(intValue,kCFNumberShortType,&i);
                 [_leftStickDeadzone setIntValue:i];
+                [_leftStickDeadzoneAlt setIntValue:i];
                 [_leftDeadZone setVal:i];
-            } else NSLog(@"No value for DeadzoneLeft");
+                [_leftStickAnalog setDeadzone:i];
+            } else NSLog(@"No value for DeadzoneLeft\n");
             if(CFDictionaryGetValueIfPresent(dict,CFSTR("InvertRightX"),(void*)&boolValue)) {
                 [_rightStickInvertX setState:CFBooleanGetValue(boolValue)?NSOnState:NSOffState];
-            } else NSLog(@"No value for InvertRightX");
+                [_rightStickInvertXAlt setState:CFBooleanGetValue(boolValue)?NSOnState:NSOffState];
+            } else NSLog(@"No value for InvertRightX\n");
             if(CFDictionaryGetValueIfPresent(dict,CFSTR("InvertRightY"),(void*)&boolValue)) {
                 [_rightStickInvertY setState:CFBooleanGetValue(boolValue)?NSOnState:NSOffState];
-            } else NSLog(@"No value for InvertRightY");
+                [_rightStickInvertYAlt setState:CFBooleanGetValue(boolValue)?NSOnState:NSOffState];
+            } else NSLog(@"No value for InvertRightY\n");
             if(CFDictionaryGetValueIfPresent(dict,CFSTR("RelativeRight"),(void*)&boolValue)) {
                 BOOL enable=CFBooleanGetValue(boolValue);
                 [_rightLinked setState:enable?NSOnState:NSOffState];
+                [_rightLinkedAlt setState:enable?NSOnState:NSOffState];
                 [_rightDeadZone setLinked:enable];
-            } else NSLog(@"No value for RelativeRight");
+                [_rightStickAnalog setLinked:enable];
+            } else NSLog(@"No value for RelativeRight\n");
             if(CFDictionaryGetValueIfPresent(dict,CFSTR("DeadzoneRight"),(void*)&intValue)) {
                 UInt16 i;
                 
                 CFNumberGetValue(intValue,kCFNumberShortType,&i);
                 [_rightStickDeadzone setIntValue:i];
+                [_rightStickDeadzoneAlt setIntValue:i];
                 [_rightDeadZone setVal:i];
-            } else NSLog(@"No value for DeadzoneRight");
-            CFRelease(dict);
-        } else NSLog(@"No settings found");
+                [_rightStickAnalog setDeadzone:i];
+            } else NSLog(@"No value for DeadzoneRight\n");
+            
+            if(CFDictionaryGetValueIfPresent(dict,CFSTR("ControllerType"),(void*)&intValue)) {
+                NSNumber *num = (__bridge NSNumber *)intValue;
+                controllerType = (ControllerType)[num integerValue];
+                NSLog(@"CONTROLLER TYPE PREF - %@, %lu\n", num, controllerType);
+            } else NSLog(@"No value for ControllerType\n");
+            if(CFDictionaryGetValueIfPresent(dict,CFSTR("XoneRumbleType"),(void*)&intValue)) {
+                NSNumber *num = (__bridge NSNumber *)intValue;
+                [_xoneRumbleOptions setState:[num integerValue]];
+            } else NSLog(@"No value for XoneRumbleType\n");
+            
+            if(CFDictionaryGetValueIfPresent(dict,CFSTR("BindingUp"),(void*)&intValue)) {
+                NSNumber *num = (__bridge NSNumber *)intValue;
+                [MyWhole360ControllerMapper mapping][0] = [num intValue];
+            } else NSLog(@"No value for BindingUp\n");
+            if(CFDictionaryGetValueIfPresent(dict,CFSTR("BindingDown"),(void*)&intValue)) {
+                NSNumber *num = (__bridge NSNumber *)intValue;
+                [MyWhole360ControllerMapper mapping][1] = [num intValue];
+            } else NSLog(@"No value for BindingDown\n");
+            if(CFDictionaryGetValueIfPresent(dict,CFSTR("BindingLeft"),(void*)&intValue)) {
+                NSNumber *num = (__bridge NSNumber *)intValue;
+                [MyWhole360ControllerMapper mapping][2] = [num intValue];
+            } else NSLog(@"No value for BindingLeft\n");
+            if(CFDictionaryGetValueIfPresent(dict,CFSTR("BindingRight"),(void*)&intValue)) {
+                NSNumber *num = (__bridge NSNumber *)intValue;
+                [MyWhole360ControllerMapper mapping][3] = [num intValue];
+            } else NSLog(@"No value for BindingRight\n");
+            if(CFDictionaryGetValueIfPresent(dict,CFSTR("BindingStart"),(void*)&intValue)) {
+                NSNumber *num = (__bridge NSNumber *)intValue;
+                [MyWhole360ControllerMapper mapping][4] = [num intValue];
+            } else NSLog(@"No value for BindingStart\n");
+            if(CFDictionaryGetValueIfPresent(dict,CFSTR("BindingBack"),(void*)&intValue)) {
+                NSNumber *num = (__bridge NSNumber *)intValue;
+                [MyWhole360ControllerMapper mapping][5] = [num intValue];
+            } else NSLog(@"No value for BindingBack\n");
+            if(CFDictionaryGetValueIfPresent(dict,CFSTR("BindingLSC"),(void*)&intValue)) {
+                NSNumber *num = (__bridge NSNumber *)intValue;
+                [MyWhole360ControllerMapper mapping][6] = [num intValue];
+            } else NSLog(@"No value for BindingLSC\n");
+            if(CFDictionaryGetValueIfPresent(dict,CFSTR("BindingRSC"),(void*)&intValue)) {
+                NSNumber *num = (__bridge NSNumber *)intValue;
+                [MyWhole360ControllerMapper mapping][7] = [num intValue];
+            } else NSLog(@"No value for BindingRSC\n");
+            if(CFDictionaryGetValueIfPresent(dict,CFSTR("BindingLB"),(void*)&intValue)) {
+                NSNumber *num = (__bridge NSNumber *)intValue;
+                [MyWhole360ControllerMapper mapping][8] = [num intValue];
+            } else NSLog(@"No value for BindingLB\n");
+            if(CFDictionaryGetValueIfPresent(dict,CFSTR("BindingRB"),(void*)&intValue)) {
+                NSNumber *num = (__bridge NSNumber *)intValue;
+                [MyWhole360ControllerMapper mapping][9] = [num intValue];
+            } else NSLog(@"No value for BindingRB\n");
+            if(CFDictionaryGetValueIfPresent(dict,CFSTR("BindingGuide"),(void*)&intValue)) {
+                NSNumber *num = (__bridge NSNumber *)intValue;
+                [MyWhole360ControllerMapper mapping][10] = [num intValue];
+            } else NSLog(@"No value for BindingGuide\n");
+            if(CFDictionaryGetValueIfPresent(dict,CFSTR("BindingA"),(void*)&intValue)) {
+                NSNumber *num = (__bridge NSNumber *)intValue;
+                [MyWhole360ControllerMapper mapping][11] = [num intValue];
+            } else NSLog(@"No value for BindingA\n");
+            if(CFDictionaryGetValueIfPresent(dict,CFSTR("BindingB"),(void*)&intValue)) {
+                NSNumber *num = (__bridge NSNumber *)intValue;
+                [MyWhole360ControllerMapper mapping][12] = [num intValue];
+            } else NSLog(@"No value for BindingB\n");
+            if(CFDictionaryGetValueIfPresent(dict,CFSTR("BindingX"),(void*)&intValue)) {
+                NSNumber *num = (__bridge NSNumber *)intValue;
+                [MyWhole360ControllerMapper mapping][13] = [num intValue];
+            } else NSLog(@"No value for BindingX\n");
+            if(CFDictionaryGetValueIfPresent(dict,CFSTR("BindingY"),(void*)&intValue)) {
+                NSNumber *num = (__bridge NSNumber *)intValue;
+                [MyWhole360ControllerMapper mapping][14] = [num intValue];
+            } else NSLog(@"No value for BindingY\n");
+        } else NSLog(@"No settings found\n");
     }
     // Enable GUI components
     [self inputEnable:YES];
@@ -568,12 +699,16 @@ static void callbackHandleDevice(void *param,io_iterator_t iterator)
             [_batteryStatus setHidden:YES];
         }
     }
+    
+    [_mappingTable reloadData];
 }
 
 // Clear out the device lists
 - (void)deleteDeviceList
 {
     [_deviceList removeAllItems];
+    [_deviceListBinding removeAllItems];
+    [_deviceListDeadzones removeAllItems];
     [_deviceArray removeAllObjects];
 }
 
@@ -594,6 +729,8 @@ static void callbackHandleDevice(void *param,io_iterator_t iterator)
     ioReturn=IOServiceGetMatchingServices(_masterPort,hidDictionary,&iterator);
     if((ioReturn != kIOReturnSuccess) || (iterator == 0)) {
         [_deviceList addItemWithTitle:NO_ITEMS];
+        [_deviceListBinding addItemWithTitle:NO_ITEMS];
+        [_deviceListDeadzones addItemWithTitle:NO_ITEMS];
         return;
     }
     
@@ -614,10 +751,16 @@ static void callbackHandleDevice(void *param,io_iterator_t iterator)
         if (name == nil)
             name = @"Generic Controller";
         [_deviceList addItemWithTitle:[NSString stringWithFormat:@"%i: %@ (%@)", ++count, name, deviceWireless ? @"Wireless" : @"Wired"]];
+        [_deviceListBinding addItemWithTitle:[NSString stringWithFormat:@"%i: %@ (%@)", count, name, deviceWireless ? @"Wireless" : @"Wired"]];
+        [_deviceListDeadzones addItemWithTitle:[NSString stringWithFormat:@"%i: %@ (%@)", count, name, deviceWireless ? @"Wireless" : @"Wired"]];
         [_deviceArray addObject:item];
     }
     IOObjectRelease(iterator);
-    if (count==0) [_deviceList addItemWithTitle:NO_ITEMS];
+    if (count==0) {
+        [_deviceList addItemWithTitle:NO_ITEMS];
+        [_deviceListBinding addItemWithTitle:NO_ITEMS];
+        [_deviceListDeadzones addItemWithTitle:NO_ITEMS];
+    }
     [self startDevice];
 }
 
@@ -689,12 +832,50 @@ static void callbackHandleDevice(void *param,io_iterator_t iterator)
 // Handle selection from drop down menu
 - (IBAction)selectDevice:(id)sender
 {
+    NSInteger tabIndex = [_tabView indexOfTabViewItem:[_tabView selectedTabViewItem]];
+    if (tabIndex == 0) { // Controller Test
+        [_deviceListBinding selectItemAtIndex:[_deviceList indexOfSelectedItem]];
+        [_deviceListDeadzones selectItemAtIndex:[_deviceList indexOfSelectedItem]];
+    }
+    else if (tabIndex == 1) { // Binding Tab
+        [_deviceList selectItemAtIndex:[_deviceListBinding indexOfSelectedItem]];
+        [_deviceListDeadzones selectItemAtIndex:[_deviceListBinding indexOfSelectedItem]];
+    }
+    else if (tabIndex == 2) { // Deadzones Tab
+        [_deviceList selectItemAtIndex:[_deviceListDeadzones indexOfSelectedItem]];
+        [_deviceListBinding selectItemAtIndex:[_deviceListDeadzones indexOfSelectedItem]];
+    }
+    
     [self startDevice];
 }
 
 // Handle changing a setting
 - (IBAction)changeSetting:(id)sender
 {
+    // Sync settings between tabs
+    NSInteger tabIndex = [_tabView indexOfTabViewItem:[_tabView selectedTabViewItem]];
+    
+    if (tabIndex == 0) { // Controller Test
+        [_leftLinkedAlt setState:[_leftLinked state]];
+        [_leftStickDeadzoneAlt setDoubleValue:[_leftStickDeadzone doubleValue]];
+        [_leftStickInvertXAlt setState:[_leftStickInvertX state]];
+        [_leftStickInvertYAlt setState:[_leftStickInvertY state]];
+        [_rightLinkedAlt setState:[_rightLinked state]];
+        [_rightStickDeadzoneAlt setDoubleValue:[_rightStickDeadzone doubleValue]];
+        [_rightStickInvertXAlt setState:[_rightStickInvertX state]];
+        [_rightStickInvertYAlt setState:[_rightStickInvertY state]];
+    }
+    else if (tabIndex == 2) { // Deadzone Tab
+        [_leftLinked setState:[_leftLinkedAlt state]];
+        [_leftStickDeadzone setDoubleValue:[_leftStickDeadzoneAlt doubleValue]];
+        [_leftStickInvertX setState:[_leftStickInvertXAlt state]];
+        [_leftStickInvertY setState:[_leftStickInvertYAlt state]];
+        [_rightLinked setState:[_rightLinkedAlt state]];
+        [_rightStickDeadzone setDoubleValue:[_rightStickDeadzoneAlt doubleValue]];
+        [_rightStickInvertX setState:[_rightStickInvertXAlt state]];
+        [_rightStickInvertY setState:[_rightStickInvertYAlt state]];
+    }
+    
     // Create dictionary
     NSDictionary *dict = @{@"InvertLeftX": @((BOOL)([_leftStickInvertX state]==NSOnState)),
                            @"InvertLeftY": @((BOOL)([_leftStickInvertY state]==NSOnState)),
@@ -703,16 +884,37 @@ static void callbackHandleDevice(void *param,io_iterator_t iterator)
                            @"DeadzoneLeft": @((UInt16)[_leftStickDeadzone doubleValue]),
                            @"DeadzoneRight": @((UInt16)[_rightStickDeadzone doubleValue]),
                            @"RelativeLeft": @((BOOL)([_leftLinked state]==NSOnState)),
-                           @"RelativeRight": @((BOOL)([_rightLinked state]==NSOnState))};
+                           @"RelativeRight": @((BOOL)([_rightLinked state]==NSOnState)),
+                           @"ControllerType": @((UInt8)(controllerType)),
+                           @"XoneRumbleType": @((UInt8)([_xoneRumbleOptions indexOfSelectedItem])),
+                           @"BindingUp": @((UInt8)([MyWhole360ControllerMapper mapping][0])),
+                           @"BindingDown": @((UInt8)([MyWhole360ControllerMapper mapping][1])),
+                           @"BindingLeft": @((UInt8)([MyWhole360ControllerMapper mapping][2])),
+                           @"BindingRight": @((UInt8)([MyWhole360ControllerMapper mapping][3])),
+                           @"BindingStart": @((UInt8)([MyWhole360ControllerMapper mapping][4])),
+                           @"BindingBack": @((UInt8)([MyWhole360ControllerMapper mapping][5])),
+                           @"BindingLSC": @((UInt8)([MyWhole360ControllerMapper mapping][6])),
+                           @"BindingRSC": @((UInt8)([MyWhole360ControllerMapper mapping][7])),
+                           @"BindingLB": @((UInt8)([MyWhole360ControllerMapper mapping][8])),
+                           @"BindingRB": @((UInt8)([MyWhole360ControllerMapper mapping][9])),
+                           @"BindingGuide": @((UInt8)([MyWhole360ControllerMapper mapping][10])),
+                           @"BindingA": @((UInt8)([MyWhole360ControllerMapper mapping][11])),
+                           @"BindingB": @((UInt8)([MyWhole360ControllerMapper mapping][12])),
+                           @"BindingX": @((UInt8)([MyWhole360ControllerMapper mapping][13])),
+                           @"BindingY": @((UInt8)([MyWhole360ControllerMapper mapping][14])),};
     
     // Set property
     IORegistryEntrySetCFProperties(registryEntry, (__bridge CFTypeRef)(dict));
     SetController(GetSerialNumber(registryEntry), dict);
     // Update UI
     [_leftDeadZone setLinked:[_leftLinked state] == NSOnState];
+    [_leftStickAnalog setLinked:[_leftLinked state] == NSOnState];
     [_leftDeadZone setVal:[_leftStickDeadzone doubleValue]];
+    [_leftStickAnalog setDeadzone:[_leftStickDeadzone doubleValue]];
     [_rightDeadZone setLinked:[_rightLinked state] == NSOnState];
+    [_rightStickAnalog setLinked:[_rightLinked state] == NSOnState];
     [_rightDeadZone setVal:[_rightStickDeadzone doubleValue]];
+    [_rightStickAnalog setDeadzone:[_rightStickDeadzone doubleValue]];
 }
 
 // Handle I/O Kit device add/remove
@@ -736,4 +938,17 @@ static void callbackHandleDevice(void *param,io_iterator_t iterator)
 - (IBAction)showAboutPopover:(id)sender {
     [_aboutPopover showRelativeToRect:[sender bounds] ofView:sender preferredEdge:NSMinXEdge];
 }
+
+- (IBAction)startRemappingPressed:(id)sender {
+    if (![_wholeControllerMapper isMapping])
+        [_wholeControllerMapper runMapperWithButton:_remappingButton andOwner:self];
+    else
+        [_wholeControllerMapper reset];
+}
+
+- (IBAction)resetRemappingPressed:(id)sender {
+    [_remappingButton setState:NSOffState];
+    [_wholeControllerMapper reset];
+}
+
 @end

--- a/Pref360Control/en.lproj/Pref360ControlPref.xib
+++ b/Pref360Control/en.lproj/Pref360ControlPref.xib
@@ -460,7 +460,7 @@
                                         </scrollView>
                                         <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Zb5-mS-Byj">
                                             <rect key="frame" x="497" y="41" width="147" height="32"/>
-                                            <buttonCell key="cell" type="push" title="Reset Remapping" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="fLu-85-Jz7">
+                                            <buttonCell key="cell" type="push" title="Reset Mapping" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="fLu-85-Jz7">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                 <font key="font" metaFont="system"/>
                                             </buttonCell>

--- a/Pref360Control/en.lproj/Pref360ControlPref.xib
+++ b/Pref360Control/en.lproj/Pref360ControlPref.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6254" systemVersion="14B25" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6254" systemVersion="14C109" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
         <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="6254"/>
@@ -10,22 +10,41 @@
                 <outlet property="_window" destination="3g4-A8-wfV" id="jZs-Hc-dO7"/>
                 <outlet property="aboutPopover" destination="w7a-sF-aQr" id="wC1-E6-pB2"/>
                 <outlet property="batteryStatus" destination="2nr-yn-Nnu" id="5Q6-hJ-Qfy"/>
+                <outlet property="bindingInputColumn" destination="CU8-av-rwl" id="8eS-Q0-knN"/>
                 <outlet property="deviceList" destination="DoB-vG-8fZ" id="b90-MV-zZr"/>
+                <outlet property="deviceListBinding" destination="rCs-qF-rWd" id="khP-yt-mEj"/>
+                <outlet property="deviceListDeadzones" destination="v9g-pO-cIT" id="vYT-DU-mVt"/>
                 <outlet property="deviceLister" destination="221" id="226"/>
                 <outlet property="leftDeadZone" destination="PUC-ti-HkQ" id="LLa-TQ-jre"/>
                 <outlet property="leftLinked" destination="FGM-yX-zMk" id="bmO-fI-Y3c"/>
+                <outlet property="leftLinkedAlt" destination="O2Y-4P-SwU" id="yEA-5b-yXV"/>
+                <outlet property="leftStickAnalog" destination="zxH-Fb-uux" id="Cmt-NS-Ky8"/>
                 <outlet property="leftStickDeadzone" destination="4Rd-ha-aE9" id="PaS-sH-2Hq"/>
+                <outlet property="leftStickDeadzoneAlt" destination="w59-p2-gVR" id="ZP4-0g-ySs"/>
                 <outlet property="leftStickInvertX" destination="0e9-VK-hzl" id="iqC-6B-0h7"/>
+                <outlet property="leftStickInvertXAlt" destination="bu6-hT-9ND" id="AtN-al-F8N"/>
                 <outlet property="leftStickInvertY" destination="VrN-HB-a4l" id="r9X-xU-v4z"/>
+                <outlet property="leftStickInvertYAlt" destination="ejG-0P-eK6" id="zm6-Vd-Q4a"/>
                 <outlet property="leftTrigger" destination="auT-ii-eXB" id="gxi-ed-Onq"/>
+                <outlet property="mappingTable" destination="9SZ-KC-9Y6" id="hzo-cd-Nq7"/>
                 <outlet property="powerOff" destination="Ici-JG-9U7" id="aLb-dv-ZJp"/>
+                <outlet property="remappingButton" destination="yAI-iC-6ZJ" id="zms-RE-c9J"/>
+                <outlet property="remappingResetButton" destination="Zb5-mS-Byj" id="7G0-9w-yIf"/>
                 <outlet property="rightDeadZone" destination="PVh-uO-wxu" id="8yp-z7-tg6"/>
                 <outlet property="rightLinked" destination="Uqs-h4-SLy" id="AzN-4j-3LK"/>
+                <outlet property="rightLinkedAlt" destination="Hxn-JO-bAn" id="QEV-QI-uqy"/>
+                <outlet property="rightStickAnalog" destination="vof-lR-v7y" id="GBP-S7-9FL"/>
                 <outlet property="rightStickDeadzone" destination="Wxg-qH-eBn" id="RIH-fl-FdX"/>
+                <outlet property="rightStickDeadzoneAlt" destination="dhB-Ed-Icp" id="soA-3t-WSf"/>
                 <outlet property="rightStickInvertX" destination="ysF-It-Kag" id="Ehk-db-zbR"/>
+                <outlet property="rightStickInvertXAlt" destination="Xd5-aE-ddG" id="hE3-ZW-xcn"/>
                 <outlet property="rightStickInvertY" destination="jdE-2i-HVe" id="dwF-3g-pwn"/>
+                <outlet property="rightStickInvertYAlt" destination="ASV-58-sZ1" id="ADg-YG-KGA"/>
                 <outlet property="rightTrigger" destination="BLH-hs-koP" id="G2s-bp-VgK"/>
+                <outlet property="tabView" destination="hF4-J0-ko4" id="2mL-IX-fVY"/>
                 <outlet property="wholeController" destination="ILA-Sd-ahY" id="Mr1-K0-ZLS"/>
+                <outlet property="wholeControllerMapper" destination="jmX-SJ-ewe" id="VCe-Dg-aIB"/>
+                <outlet property="xoneRumbleOptions" destination="g1A-0k-b7Y" id="2qP-z1-4Rn"/>
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
@@ -34,11 +53,25 @@
         <window title="&lt;&lt; do not localize &gt;&gt;" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" deferred="NO" oneShot="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="3g4-A8-wfV" userLabel="PrefPane">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
             <rect key="contentRect" x="374" y="240" width="658" height="420"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1280" height="777"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1177"/>
             <view key="contentView" id="Z4H-05-G2i">
                 <rect key="frame" x="0.0" y="0.0" width="658" height="420"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 <subviews>
+                    <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="FxU-HG-Eem">
+                        <rect key="frame" x="194" y="390" width="270" height="23"/>
+                        <segmentedCell key="cell" borderStyle="border" alignment="left" style="smallSquare" trackingMode="selectOne" id="4as-1K-roV">
+                            <font key="font" metaFont="system"/>
+                            <segments>
+                                <segment label="Controller Test" selected="YES"/>
+                                <segment label="Binding" tag="1"/>
+                                <segment label="Deadzones"/>
+                            </segments>
+                        </segmentedCell>
+                        <connections>
+                            <action selector="takeSelectedTabViewItemFromSender:" target="hF4-J0-ko4" id="uZH-FR-qat"/>
+                        </connections>
+                    </segmentedControl>
                     <tabView drawsBackground="NO" type="noTabsNoBorder" translatesAutoresizingMaskIntoConstraints="NO" id="hF4-J0-ko4">
                         <rect key="frame" x="0.0" y="0.0" width="658" height="381"/>
                         <font key="font" metaFont="system"/>
@@ -151,13 +184,13 @@
                                                 <action selector="selectDevice:" target="-2" id="gsM-0x-TTV"/>
                                             </connections>
                                         </popUpButton>
-                                        <box autoresizesSubviews="NO" title="Left Stick" borderType="line" translatesAutoresizingMaskIntoConstraints="NO" id="ZlQ-UU-WB8">
+                                        <box autoresizesSubviews="NO" misplaced="YES" title="Left Stick" borderType="line" translatesAutoresizingMaskIntoConstraints="NO" id="ZlQ-UU-WB8">
                                             <rect key="frame" x="490" y="226" width="151" height="124"/>
                                             <view key="contentView">
                                                 <rect key="frame" x="1" y="1" width="149" height="108"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
-                                                    <button translatesAutoresizingMaskIntoConstraints="NO" id="0e9-VK-hzl">
+                                                    <button misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0e9-VK-hzl">
                                                         <rect key="frame" x="16" y="82" width="69" height="18"/>
                                                         <buttonCell key="cell" type="check" title="Invert X" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="5wf-7e-ekz">
                                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -167,7 +200,7 @@
                                                             <action selector="changeSetting:" target="-2" id="Oy1-El-lBZ"/>
                                                         </connections>
                                                     </button>
-                                                    <button translatesAutoresizingMaskIntoConstraints="NO" id="VrN-HB-a4l">
+                                                    <button misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VrN-HB-a4l">
                                                         <rect key="frame" x="16" y="62" width="70" height="18"/>
                                                         <buttonCell key="cell" type="check" title="Invert Y" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="RFR-wA-1SW">
                                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -178,7 +211,7 @@
                                                         </connections>
                                                     </button>
                                                     <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="4Rd-ha-aE9">
-                                                        <rect key="frame" x="16" y="37" width="117" height="21"/>
+                                                        <rect key="frame" x="16" y="37" width="117" height="20"/>
                                                         <sliderCell key="cell" continuous="YES" alignment="left" maxValue="32768" tickMarkPosition="above" sliderType="linear" id="pUW-BW-6Gu">
                                                             <font key="font" size="12" name="Helvetica"/>
                                                         </sliderCell>
@@ -214,13 +247,13 @@
                                             <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
                                             <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         </box>
-                                        <box autoresizesSubviews="NO" title="Right Stick" borderType="line" translatesAutoresizingMaskIntoConstraints="NO" id="cqy-WX-TEQ">
+                                        <box autoresizesSubviews="NO" misplaced="YES" title="Right Stick" borderType="line" translatesAutoresizingMaskIntoConstraints="NO" id="cqy-WX-TEQ">
                                             <rect key="frame" x="490" y="98" width="151" height="124"/>
                                             <view key="contentView">
                                                 <rect key="frame" x="1" y="1" width="149" height="108"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
-                                                    <button translatesAutoresizingMaskIntoConstraints="NO" id="ysF-It-Kag">
+                                                    <button misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ysF-It-Kag">
                                                         <rect key="frame" x="16" y="82" width="69" height="18"/>
                                                         <buttonCell key="cell" type="check" title="Invert X" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="acH-i4-MwR">
                                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -230,7 +263,7 @@
                                                             <action selector="changeSetting:" target="-2" id="HPo-ks-d8X"/>
                                                         </connections>
                                                     </button>
-                                                    <button translatesAutoresizingMaskIntoConstraints="NO" id="jdE-2i-HVe">
+                                                    <button misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jdE-2i-HVe">
                                                         <rect key="frame" x="16" y="62" width="70" height="18"/>
                                                         <buttonCell key="cell" type="check" title="Invert Y" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="8Vm-ce-hhc">
                                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -251,7 +284,7 @@
                                                         </connections>
                                                     </button>
                                                     <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Wxg-qH-eBn">
-                                                        <rect key="frame" x="16" y="37" width="117" height="21"/>
+                                                        <rect key="frame" x="16" y="37" width="117" height="20"/>
                                                         <sliderCell key="cell" continuous="YES" alignment="left" maxValue="32768" tickMarkPosition="above" sliderType="linear" id="H8P-Ic-jNd">
                                                             <font key="font" size="12" name="Helvetica"/>
                                                         </sliderCell>
@@ -277,6 +310,31 @@
                                             <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
                                             <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         </box>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="OTj-lL-cwP">
+                                            <rect key="frame" x="505" y="77" width="120" height="17"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Xbox One Rumble:" id="eqi-tt-Lwa">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="g1A-0k-b7Y">
+                                            <rect key="frame" x="497" y="45" width="137" height="26"/>
+                                            <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="o1g-Uv-SAa">
+                                                <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="menu"/>
+                                                <menu key="menu" id="AI9-wk-ula">
+                                                    <items>
+                                                        <menuItem title="Rumble" id="JAa-MJ-QBl"/>
+                                                        <menuItem title="Item 2" id="4up-mH-0Mb"/>
+                                                        <menuItem title="Item 3" id="Dr1-vW-fhR"/>
+                                                    </items>
+                                                </menu>
+                                            </popUpButtonCell>
+                                            <connections>
+                                                <action selector="changeSetting:" target="-2" id="v1h-mW-iCb"/>
+                                            </connections>
+                                        </popUpButton>
                                     </subviews>
                                     <constraints>
                                         <constraint firstItem="ILA-Sd-ahY" firstAttribute="top" secondItem="ZlQ-UU-WB8" secondAttribute="top" id="3fS-0G-1A4"/>
@@ -296,41 +354,299 @@
                                     </constraints>
                                 </view>
                             </tabViewItem>
-                            <tabViewItem label="Other" identifier="2" id="6In-9m-Iqh">
+                            <tabViewItem label="Tweaking" identifier="2" id="6In-9m-Iqh">
                                 <view key="view" id="apT-j1-uIX">
                                     <rect key="frame" x="0.0" y="0.0" width="658" height="381"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="s2G-7t-Br7">
-                                            <rect key="frame" x="198" y="157" width="263" height="67"/>
-                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Other Tab" id="kZb-uZ-nid">
-                                                <font key="font" metaFont="systemBold" size="56"/>
-                                                <color key="textColor" name="quaternaryLabelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
+                                        <popUpButton horizontalHuggingPriority="249" verticalHuggingPriority="750" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rCs-qF-rWd">
+                                            <rect key="frame" x="18" y="357" width="623" height="26"/>
+                                            <popUpButtonCell key="cell" type="push" title="Item1" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="Fqs-9N-l7A" id="pey-Hr-vWo">
+                                                <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="menu"/>
+                                                <menu key="menu" title="OtherViews" id="rYq-DA-bYc">
+                                                    <items>
+                                                        <menuItem title="Item1" state="on" id="Fqs-9N-l7A"/>
+                                                        <menuItem title="Item2" id="OZ9-jd-gMM"/>
+                                                        <menuItem title="Item3" id="GKV-5p-R8F"/>
+                                                    </items>
+                                                </menu>
+                                            </popUpButtonCell>
+                                            <connections>
+                                                <action selector="selectDevice:" target="-2" id="hQP-9h-SV0"/>
+                                            </connections>
+                                        </popUpButton>
+                                        <customView ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jmX-SJ-ewe" customClass="MyWhole360ControllerMapper">
+                                            <rect key="frame" x="20" y="20" width="465" height="330"/>
+                                            <subviews>
+                                                <button hidden="YES" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aM0-GE-bqq">
+                                                    <rect key="frame" x="207" y="-3" width="50" height="50"/>
+                                                    <buttonCell key="cell" type="bevel" bezelStyle="regularSquare" image="PowerOffTemplate" imagePosition="overlaps" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="EaU-AD-Hjh">
+                                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                        <font key="font" metaFont="system"/>
+                                                    </buttonCell>
+                                                    <connections>
+                                                        <action selector="powerOff:" target="-2" id="YvW-C5-6li"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstAttribute="centerX" secondItem="aM0-GE-bqq" secondAttribute="centerX" id="NIM-l3-ZLe"/>
+                                                <constraint firstAttribute="height" constant="330" id="gSA-Sh-Nq6"/>
+                                                <constraint firstAttribute="bottom" secondItem="aM0-GE-bqq" secondAttribute="bottom" id="kQj-kg-oYS"/>
+                                                <constraint firstAttribute="width" constant="465" id="uCz-5w-JdS"/>
+                                            </constraints>
+                                        </customView>
+                                        <scrollView fixedFrame="YES" autohidesScrollers="YES" horizontalLineScroll="16" horizontalPageScroll="10" verticalLineScroll="16" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="w5N-Ik-hWq">
+                                            <rect key="frame" x="497" y="89" width="147" height="261"/>
+                                            <clipView key="contentView" misplaced="YES" id="SaB-pO-6ME">
+                                                <rect key="frame" x="1" y="0.0" width="238" height="134"/>
+                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                <subviews>
+                                                    <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="14" headerView="Zwr-si-a4c" id="9SZ-KC-9Y6">
+                                                        <rect key="frame" x="0.0" y="0.0" width="145" height="16"/>
+                                                        <autoresizingMask key="autoresizingMask"/>
+                                                        <size key="intercellSpacing" width="1" height="2"/>
+                                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                        <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
+                                                        <tableColumns>
+                                                            <tableColumn identifier="binding" width="72" minWidth="40" maxWidth="1000" id="VVi-lm-klv">
+                                                                <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Binding">
+                                                                    <font key="font" metaFont="smallSystem"/>
+                                                                    <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                    <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                                                </tableHeaderCell>
+                                                                <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="left" title="Text Cell" id="mve-gU-Nz5">
+                                                                    <font key="font" metaFont="system"/>
+                                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                    <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                </textFieldCell>
+                                                                <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                            </tableColumn>
+                                                            <tableColumn identifier="input" width="71" minWidth="10" maxWidth="3.4028234663852886e+38" id="CU8-av-rwl">
+                                                                <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Input">
+                                                                    <font key="font" metaFont="smallSystem"/>
+                                                                    <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                    <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                                                </tableHeaderCell>
+                                                                <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="left" title="Text Cell" id="qSp-FJ-2fV">
+                                                                    <font key="font" metaFont="system"/>
+                                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                    <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                </textFieldCell>
+                                                                <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                            </tableColumn>
+                                                        </tableColumns>
+                                                        <connections>
+                                                            <outlet property="dataSource" destination="6cy-Ql-rP7" id="gMg-mz-dhs"/>
+                                                            <outlet property="delegate" destination="6cy-Ql-rP7" id="ZbM-yI-O78"/>
+                                                        </connections>
+                                                    </tableView>
+                                                </subviews>
+                                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </clipView>
+                                            <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="LWD-pC-O65">
+                                                <rect key="frame" x="1" y="119" width="223" height="15"/>
+                                                <autoresizingMask key="autoresizingMask"/>
+                                            </scroller>
+                                            <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="fTK-Gc-4OH">
+                                                <rect key="frame" x="224" y="17" width="15" height="102"/>
+                                                <autoresizingMask key="autoresizingMask"/>
+                                            </scroller>
+                                            <tableHeaderView key="headerView" id="Zwr-si-a4c">
+                                                <rect key="frame" x="0.0" y="0.0" width="238" height="17"/>
+                                                <autoresizingMask key="autoresizingMask"/>
+                                            </tableHeaderView>
+                                        </scrollView>
+                                        <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Zb5-mS-Byj">
+                                            <rect key="frame" x="497" y="41" width="147" height="32"/>
+                                            <buttonCell key="cell" type="push" title="Reset Remapping" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="fLu-85-Jz7">
+                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                            </buttonCell>
+                                            <connections>
+                                                <action selector="resetRemappingPressed:" target="-2" id="nLC-NT-tM4"/>
+                                            </connections>
+                                        </button>
+                                        <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="yAI-iC-6ZJ">
+                                            <rect key="frame" x="497" y="13" width="147" height="32"/>
+                                            <buttonCell key="cell" type="push" title="Start Remapping" alternateTitle="Cancel Remapping" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="zgp-Mz-PQL">
+                                                <behavior key="behavior" pushIn="YES" changeContents="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="system"/>
+                                            </buttonCell>
+                                            <connections>
+                                                <action selector="startRemappingPressed:" target="-2" id="bKs-m1-pd2"/>
+                                            </connections>
+                                        </button>
                                     </subviews>
                                     <constraints>
-                                        <constraint firstAttribute="centerX" secondItem="s2G-7t-Br7" secondAttribute="centerX" id="qQQ-bW-KTN"/>
-                                        <constraint firstAttribute="centerY" secondItem="s2G-7t-Br7" secondAttribute="centerY" id="sJr-Ah-We6"/>
+                                        <constraint firstItem="jmX-SJ-ewe" firstAttribute="top" secondItem="rCs-qF-rWd" secondAttribute="bottom" constant="10" id="UUr-wh-144"/>
                                     </constraints>
+                                </view>
+                            </tabViewItem>
+                            <tabViewItem label="Deadzones" identifier="" id="fN4-Zi-Mei">
+                                <view key="view" id="fis-az-lAc">
+                                    <rect key="frame" x="0.0" y="0.0" width="658" height="381"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <subviews>
+                                        <box autoresizesSubviews="NO" ambiguous="YES" misplaced="YES" title="Left Stick" borderType="line" translatesAutoresizingMaskIntoConstraints="NO" id="XdF-ba-S8X">
+                                            <rect key="frame" x="138" y="89" width="151" height="124"/>
+                                            <view key="contentView">
+                                                <rect key="frame" x="1" y="1" width="149" height="108"/>
+                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                <subviews>
+                                                    <button misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bu6-hT-9ND">
+                                                        <rect key="frame" x="16" y="82" width="69" height="18"/>
+                                                        <buttonCell key="cell" type="check" title="Invert X" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="I8N-Ll-Q29">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="system"/>
+                                                        </buttonCell>
+                                                        <connections>
+                                                            <action selector="changeSetting:" target="-2" id="VEp-AK-N8D"/>
+                                                        </connections>
+                                                    </button>
+                                                    <button misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ejG-0P-eK6">
+                                                        <rect key="frame" x="16" y="62" width="70" height="18"/>
+                                                        <buttonCell key="cell" type="check" title="Invert Y" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="C6W-9e-zqx">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="system"/>
+                                                        </buttonCell>
+                                                        <connections>
+                                                            <action selector="changeSetting:" target="-2" id="b7D-u7-Azf"/>
+                                                        </connections>
+                                                    </button>
+                                                    <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="w59-p2-gVR">
+                                                        <rect key="frame" x="16" y="37" width="117" height="20"/>
+                                                        <sliderCell key="cell" continuous="YES" alignment="left" maxValue="32768" tickMarkPosition="above" sliderType="linear" id="k4Y-aS-OZs">
+                                                            <font key="font" size="12" name="Helvetica"/>
+                                                        </sliderCell>
+                                                        <connections>
+                                                            <action selector="changeSetting:" target="-2" id="h7N-8X-dCl"/>
+                                                        </connections>
+                                                    </slider>
+                                                    <button translatesAutoresizingMaskIntoConstraints="NO" id="O2Y-4P-SwU">
+                                                        <rect key="frame" x="25" y="16" width="58" height="18"/>
+                                                        <buttonCell key="cell" type="check" title="Linked" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="k9z-Ya-OO3">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                        <connections>
+                                                            <action selector="changeSetting:" target="-2" id="MZZ-cQ-DfL"/>
+                                                        </connections>
+                                                    </button>
+                                                </subviews>
+                                            </view>
+                                            <constraints>
+                                                <constraint firstAttribute="bottom" secondItem="O2Y-4P-SwU" secondAttribute="bottom" constant="16" id="Aku-N7-uhN"/>
+                                                <constraint firstItem="O2Y-4P-SwU" firstAttribute="top" secondItem="w59-p2-gVR" secondAttribute="bottom" constant="8" symbolic="YES" id="ChU-hb-ohA"/>
+                                                <constraint firstAttribute="width" constant="145" id="Dau-Vp-cTx"/>
+                                                <constraint firstItem="ejG-0P-eK6" firstAttribute="leading" secondItem="XdF-ba-S8X" secondAttribute="leading" constant="16" id="FiC-kf-iNB"/>
+                                                <constraint firstItem="O2Y-4P-SwU" firstAttribute="leading" secondItem="XdF-ba-S8X" secondAttribute="leading" constant="26" id="Y7G-rN-YVG"/>
+                                                <constraint firstItem="bu6-hT-9ND" firstAttribute="leading" secondItem="XdF-ba-S8X" secondAttribute="leading" constant="16" id="YJM-bg-3cn"/>
+                                                <constraint firstItem="w59-p2-gVR" firstAttribute="leading" secondItem="XdF-ba-S8X" secondAttribute="leading" constant="16" id="cEG-4j-F0r"/>
+                                                <constraint firstItem="w59-p2-gVR" firstAttribute="top" secondItem="ejG-0P-eK6" secondAttribute="bottom" constant="8" symbolic="YES" id="deM-A8-KLX"/>
+                                                <constraint firstItem="ejG-0P-eK6" firstAttribute="top" secondItem="bu6-hT-9ND" secondAttribute="bottom" constant="6" symbolic="YES" id="eoW-W4-Ody"/>
+                                                <constraint firstAttribute="trailing" secondItem="w59-p2-gVR" secondAttribute="trailing" constant="16" id="fMa-zk-0RE"/>
+                                                <constraint firstItem="bu6-hT-9ND" firstAttribute="top" secondItem="XdF-ba-S8X" secondAttribute="top" constant="25" id="vki-2N-f7b"/>
+                                            </constraints>
+                                            <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
+                                            <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                        </box>
+                                        <box autoresizesSubviews="NO" ambiguous="YES" misplaced="YES" title="Right Stick" borderType="line" translatesAutoresizingMaskIntoConstraints="NO" id="TKg-sh-mjm">
+                                            <rect key="frame" x="369" y="89" width="151" height="124"/>
+                                            <view key="contentView">
+                                                <rect key="frame" x="1" y="1" width="149" height="108"/>
+                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                <subviews>
+                                                    <button misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Xd5-aE-ddG">
+                                                        <rect key="frame" x="16" y="82" width="69" height="18"/>
+                                                        <buttonCell key="cell" type="check" title="Invert X" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="elG-G6-ZET">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="system"/>
+                                                        </buttonCell>
+                                                        <connections>
+                                                            <action selector="changeSetting:" target="-2" id="qnC-Fc-dpF"/>
+                                                        </connections>
+                                                    </button>
+                                                    <button misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ASV-58-sZ1">
+                                                        <rect key="frame" x="16" y="62" width="70" height="18"/>
+                                                        <buttonCell key="cell" type="check" title="Invert Y" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="6Kn-lQ-AaB">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="system"/>
+                                                        </buttonCell>
+                                                        <connections>
+                                                            <action selector="changeSetting:" target="-2" id="3sZ-8s-1Hy"/>
+                                                        </connections>
+                                                    </button>
+                                                    <button misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hxn-JO-bAn">
+                                                        <rect key="frame" x="25" y="15" width="58" height="18"/>
+                                                        <buttonCell key="cell" type="check" title="Linked" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="hyw-2p-8xu">
+                                                            <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                            <font key="font" metaFont="smallSystem"/>
+                                                        </buttonCell>
+                                                        <connections>
+                                                            <action selector="changeSetting:" target="-2" id="nY3-vX-XFJ"/>
+                                                        </connections>
+                                                    </button>
+                                                    <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dhB-Ed-Icp">
+                                                        <rect key="frame" x="16" y="37" width="117" height="20"/>
+                                                        <sliderCell key="cell" continuous="YES" alignment="left" maxValue="32768" tickMarkPosition="above" sliderType="linear" id="1uA-oq-a0L">
+                                                            <font key="font" size="12" name="Helvetica"/>
+                                                        </sliderCell>
+                                                        <connections>
+                                                            <action selector="changeSetting:" target="-2" id="abG-xT-Duq"/>
+                                                        </connections>
+                                                    </slider>
+                                                </subviews>
+                                            </view>
+                                            <constraints>
+                                                <constraint firstItem="Xd5-aE-ddG" firstAttribute="top" secondItem="TKg-sh-mjm" secondAttribute="top" constant="25" id="5KA-O9-rZt"/>
+                                                <constraint firstItem="ASV-58-sZ1" firstAttribute="top" secondItem="Xd5-aE-ddG" secondAttribute="bottom" constant="6" id="As3-Jj-QWb"/>
+                                                <constraint firstItem="dhB-Ed-Icp" firstAttribute="top" secondItem="ASV-58-sZ1" secondAttribute="bottom" constant="8" symbolic="YES" id="IEH-1y-vrF"/>
+                                                <constraint firstItem="ASV-58-sZ1" firstAttribute="leading" secondItem="TKg-sh-mjm" secondAttribute="leading" constant="16" id="PbL-ME-KBp"/>
+                                                <constraint firstItem="Xd5-aE-ddG" firstAttribute="leading" secondItem="TKg-sh-mjm" secondAttribute="leading" constant="16" id="Pzz-pL-WIM"/>
+                                                <constraint firstItem="Hxn-JO-bAn" firstAttribute="top" secondItem="dhB-Ed-Icp" secondAttribute="bottom" constant="8" symbolic="YES" id="RXE-2b-Pfr"/>
+                                                <constraint firstItem="Hxn-JO-bAn" firstAttribute="leading" secondItem="TKg-sh-mjm" secondAttribute="leading" constant="26" id="RhU-7v-sgW"/>
+                                                <constraint firstAttribute="bottom" secondItem="Hxn-JO-bAn" secondAttribute="bottom" constant="16" id="byn-Ux-RAY"/>
+                                                <constraint firstItem="dhB-Ed-Icp" firstAttribute="leading" secondItem="TKg-sh-mjm" secondAttribute="leading" constant="16" id="qXO-vT-Xah"/>
+                                                <constraint firstAttribute="trailing" secondItem="dhB-Ed-Icp" secondAttribute="trailing" constant="16" id="vou-sF-sYR"/>
+                                                <constraint firstAttribute="width" constant="145" id="wz6-es-Xii"/>
+                                            </constraints>
+                                            <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
+                                            <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                        </box>
+                                        <popUpButton horizontalHuggingPriority="249" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="v9g-pO-cIT">
+                                            <rect key="frame" x="18" y="357" width="623" height="26"/>
+                                            <popUpButtonCell key="cell" type="push" title="Item1" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="ZBC-oI-z5d" id="LNS-E3-icM">
+                                                <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="menu"/>
+                                                <menu key="menu" title="OtherViews" id="Xzo-Df-CjB">
+                                                    <items>
+                                                        <menuItem title="Item1" state="on" id="ZBC-oI-z5d"/>
+                                                        <menuItem title="Item2" id="5Iy-WS-PHG"/>
+                                                        <menuItem title="Item3" id="xdj-AB-T4C"/>
+                                                    </items>
+                                                </menu>
+                                            </popUpButtonCell>
+                                            <connections>
+                                                <action selector="selectDevice:" target="-2" id="1tN-Qv-NBp"/>
+                                            </connections>
+                                        </popUpButton>
+                                        <customView ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zxH-Fb-uux" customClass="MyAnalogStick">
+                                            <rect key="frame" x="175" y="221" width="77" height="77"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="77" id="9bG-zZ-3pY"/>
+                                                <constraint firstAttribute="height" constant="77" id="cVr-I5-Lkr"/>
+                                            </constraints>
+                                        </customView>
+                                        <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vof-lR-v7y" customClass="MyAnalogStick">
+                                            <rect key="frame" x="406" y="221" width="77" height="77"/>
+                                        </customView>
+                                    </subviews>
                                 </view>
                             </tabViewItem>
                         </tabViewItems>
                     </tabView>
-                    <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="FxU-HG-Eem">
-                        <rect key="frame" x="232" y="390" width="194" height="23"/>
-                        <segmentedCell key="cell" borderStyle="border" alignment="left" style="smallSquare" trackingMode="selectOne" id="4as-1K-roV">
-                            <font key="font" metaFont="system"/>
-                            <segments>
-                                <segment label="Controller Test" selected="YES"/>
-                                <segment label="Other Tab" tag="1"/>
-                            </segments>
-                        </segmentedCell>
-                        <connections>
-                            <action selector="takeSelectedTabViewItemFromSender:" target="hF4-J0-ko4" id="uZH-FR-qat"/>
-                        </connections>
-                    </segmentedControl>
                 </subviews>
                 <constraints>
                     <constraint firstItem="hF4-J0-ko4" firstAttribute="top" secondItem="FxU-HG-Eem" secondAttribute="bottom" constant="10" id="2q3-1Q-tz8"/>
@@ -374,6 +690,7 @@
             </constraints>
             <point key="canvasLocation" x="149" y="1119"/>
         </view>
+        <customObject id="6cy-Ql-rP7" customClass="BindingTableView"/>
     </objects>
     <resources>
         <image name="AboutTemplate" width="20" height="20"/>


### PR DESCRIPTION
Okay there is a lot to cover. I spent all weekend putting it together. First and foremost are the known issues:
 - Because of the settings bug #67, the Xbox One rumble options will show up for all controllers, they just only do things for the Xbox One controller.
 - Second, if you hold down a trigger to create any rumble effects, it will not clean itself up upon tab change.
 - Third, the deadzones tab looks a little bit empty. Not really a big deal

### Main Panel
<img src="https://cloud.githubusercontent.com/assets/4530595/5993994/ba91bd14-aa29-11e4-9099-187941bce54e.png" width="750px"/>
Nothing too crazy here, just added the Popup box that allows the users to change where the rumbles are sent. Tested with the preference pane and Fez.

<img src="https://cloud.githubusercontent.com/assets/4530595/5993995/bd4be57a-aa29-11e4-9779-5983017dd4d5.png" width="750px"/>
To keep things from being too confusing, the buttons don't light up on this page when pressed. The image is static until mapping starts, then individual buttons will light up to denote which one needs to be pressed. Should allow for any button to look like any other button. Could potentially be used to fix issues with SDL maybe? It is as of yet untested. The list over to the side tracks the changes in buttons, but of course doesn't load properly due to #67 again.

<img src="https://cloud.githubusercontent.com/assets/4530595/5993996/bf3abf78-aa29-11e4-862f-0356c69de8a6.png" width="750px"/>
These provide a more detailed view of the deadzones, and all of the data should sync across changes made in either tab.

### Minor Improvements
 - Fixed some extra log writes from Xbox One controllers
 - Added tab based checking so that the controller doesn't rumble on every tab
 - Added setting to check type of controller. Useful for more complex art.
 - Other minor stuff.