### PR TITLE
Add rumble disable

### DIFF
--- a/360Controller/Controller.cpp
+++ b/360Controller/Controller.cpp
@@ -85,6 +85,8 @@ IOReturn Xbox360ControllerClass::setReport(IOMemoryDescriptor *report,IOHIDRepor
     char data[2];
     
     report->readBytes(0, data, 2);
+    if (GetOwner(this)->rumbleType == 1) // Don't Rumble
+        return kIOReturnSuccess;
     switch(data[0]) {
         case 0x00:  // Set force feedback
             if((data[1]!=report->getLength()) || (data[1]!=0x04)) return kIOReturnUnsupported;
@@ -382,6 +384,8 @@ IOReturn XboxOriginalControllerClass::setReport(IOMemoryDescriptor *report,IOHID
     char data[2];
     
     report->readBytes(0, data, 2);
+    if (GetOwner(this)->rumbleType == 1) // Don't Rumble
+        return kIOReturnSuccess;
     switch(data[0]) {
         case 0x00:  // Set force feedback
             if((data[1]!=report->getLength()) || (data[1]!=0x04)) return kIOReturnUnsupported;
@@ -561,7 +565,7 @@ IOReturn XboxOneControllerClass::setReport(IOMemoryDescriptor *report,IOHIDRepor
             rumble.rumbleMask = 0x0F;
             rumble.length = 0x80;
             
-            rumbleType = GetOwner(this)->xoneRumbleType;
+            rumbleType = GetOwner(this)->rumbleType;
             if (rumbleType == 0) // Default
             {
                 rumble.trigL = 0x00;
@@ -569,14 +573,18 @@ IOReturn XboxOneControllerClass::setReport(IOMemoryDescriptor *report,IOHIDRepor
                 rumble.little = data[2];
                 rumble.big = data[3];
             }
-            else if (rumbleType == 1) // Trigger
+            else if (rumbleType == 1) // None
+            {
+                return kIOReturnSuccess;
+            }
+            else if (rumbleType == 2) // Trigger
             {
                 rumble.trigL = data[2] / 2.0;
                 rumble.trigR = data[3] / 2.0;
                 rumble.little = 0x00;
                 rumble.big = 0x00;
             }
-            else if (rumbleType == 2) // Both
+            else if (rumbleType == 3) // Both
             {
                 rumble.trigL = data[2] / 2.0;
                 rumble.trigR = data[3] / 2.0;

--- a/360Controller/_60Controller.cpp
+++ b/360Controller/_60Controller.cpp
@@ -252,8 +252,8 @@ void Xbox360Peripheral::readSettings(void)
     value = OSDynamicCast(OSBoolean, dataDictionary->getObject("DeadOffRight"));
     if (value != NULL) deadOffRight = value->getValue();
 //    number = OSDynamicCast(OSNumber, dataDictionary->getObject("ControllerType")); // No use currently.
-    number = OSDynamicCast(OSNumber, dataDictionary->getObject("XoneRumbleType"));
-    if (number != NULL) xoneRumbleType = number->unsigned8BitValue();
+    number = OSDynamicCast(OSNumber, dataDictionary->getObject("rumbleType"));
+    if (number != NULL) rumbleType = number->unsigned8BitValue();
     number = OSDynamicCast(OSNumber, dataDictionary->getObject("BindingUp"));
     if (number != NULL) mapping[0] = number->unsigned32BitValue();
     number = OSDynamicCast(OSNumber, dataDictionary->getObject("BindingDown"));
@@ -317,7 +317,7 @@ bool Xbox360Peripheral::init(OSDictionary *propTable)
     deadOffLeft = false;
     deadOffRight = false;
     // Controller Specific
-    xoneRumbleType = 0;
+    rumbleType = 0;
     // Bindings
     for (int i = 0; i < 11; i++)
     {

--- a/360Controller/_60Controller.h
+++ b/360Controller/_60Controller.h
@@ -108,7 +108,7 @@ protected:
     
 public:
     // Controller specific
-    UInt8 xoneRumbleType;
+    UInt8 rumbleType;
 
     UInt8 mapping[15];
     

--- a/360Daemon/ControlPrefs.m
+++ b/360Daemon/ControlPrefs.m
@@ -52,7 +52,6 @@ void SetController(NSString *serial, NSDictionary *data)
 NSDictionary* GetController(NSString *serial)
 {
     CFPropertyListRef value;
-    
     CFPreferencesSynchronize(DOM_CONTROLLERS, kCFPreferencesAnyUser, kCFPreferencesCurrentHost);
     value = CFPreferencesCopyValue((__bridge CFStringRef)serial, DOM_CONTROLLERS, kCFPreferencesAnyUser, kCFPreferencesCurrentHost);
     return CFBridgingRelease(value);

--- a/Pref360Control/Pref360ControlPref.h
+++ b/Pref360Control/Pref360ControlPref.h
@@ -63,7 +63,7 @@ typedef NS_ENUM(NSUInteger, ControllerType) {
 @property (weak) IBOutlet MyDeadZoneViewer *leftDeadZone;
 @property (weak) IBOutlet MyDeadZoneViewer *rightDeadZone;
 @property (strong) IBOutlet NSPopover *aboutPopover;
-@property (weak) IBOutlet NSPopUpButton *xoneRumbleOptions;
+@property (weak) IBOutlet NSPopUpButton *rumbleOptions;
 
 // Binding Tab
 @property (weak) IBOutlet NSPopUpButton *deviceListBinding;

--- a/Pref360Control/Pref360ControlPref.m
+++ b/Pref360Control/Pref360ControlPref.m
@@ -86,8 +86,10 @@ static void callbackHandleDevice(void *param,io_iterator_t iterator)
 
 -(void)awakeFromNib {
     [_aboutPopover setAppearance:NSPopoverAppearanceHUD];
-    [_xoneRumbleOptions removeAllItems];
-    [_xoneRumbleOptions addItemsWithTitles:@[@"Default", @"Triggers Only", @"Both"]];
+    [_rumbleOptions removeAllItems];
+    [_rumbleOptions addItemsWithTitles:@[@"Default", @"None"]];
+    if (controllerType == XboxOneController)
+        [_rumbleOptions addItemsWithTitles:@[@"Triggers Only", @"Both"]];
 }
 
 // Set the pattern on the LEDs
@@ -347,13 +349,7 @@ static void callbackHandleDevice(void *param,io_iterator_t iterator)
     [_rightLinkedAlt setEnabled:enable];
     [_normalizeDeadzoneLeft setEnabled:enable];
     [_normalizeDeadzoneRight setEnabled:enable];
-    if (enable) { // If trying to enable, make sure its an Xbox One Controller
-//        if (controllerType == XboxOneController) // Ignore until settings are fixed (Issue #67
-            [_xoneRumbleOptions setEnabled:enable];
-    }
-    else { // Always disable
-        [_xoneRumbleOptions setEnabled:enable];
-    }
+    [_rumbleOptions setEnabled:enable];
 }
 
 // Reset GUI components
@@ -604,10 +600,10 @@ static void callbackHandleDevice(void *param,io_iterator_t iterator)
                 NSNumber *num = (__bridge NSNumber *)intValue;
                 controllerType = (ControllerType)[num integerValue];
             } else NSLog(@"No value for ControllerType\n");
-            if(CFDictionaryGetValueIfPresent(dict,CFSTR("XoneRumbleType"),(void*)&intValue)) {
+            if(CFDictionaryGetValueIfPresent(dict,CFSTR("RumbleType"),(void*)&intValue)) {
                 NSNumber *num = (__bridge NSNumber *)intValue;
-                [_xoneRumbleOptions setState:[num integerValue]];
-            } else NSLog(@"No value for XoneRumbleType\n");
+                [_rumbleOptions setState:[num integerValue]];
+            } else NSLog(@"No value for RumbleType\n");
             
             if(CFDictionaryGetValueIfPresent(dict,CFSTR("BindingUp"),(void*)&intValue)) {
                 NSNumber *num = (__bridge NSNumber *)intValue;
@@ -897,7 +893,7 @@ static void callbackHandleDevice(void *param,io_iterator_t iterator)
                            @"DeadOffLeft": @((BOOL)([_normalizeDeadzoneLeft state]==NSOnState)),
                            @"DeadOffRight": @((BOOL)([_normalizeDeadzoneRight state]==NSOnState)),
                            @"ControllerType": @((UInt8)(controllerType)),
-                           @"XoneRumbleType": @((UInt8)([_xoneRumbleOptions indexOfSelectedItem])),
+                           @"RumbleType": @((UInt8)([_rumbleOptions indexOfSelectedItem])),
                            @"BindingUp": @((UInt8)([MyWhole360ControllerMapper mapping][0])),
                            @"BindingDown": @((UInt8)([MyWhole360ControllerMapper mapping][1])),
                            @"BindingLeft": @((UInt8)([MyWhole360ControllerMapper mapping][2])),

--- a/Pref360Control/Pref360StyleKit.m
+++ b/Pref360Control/Pref360StyleKit.m
@@ -793,16 +793,16 @@
             CGFloat maxVal = max16 - rightDead;
             
             if (rightStickPosition.x > 0)
-                rightStickPosition.x = (abs(rightStickPosition.x) * maxVal / max16) + rightDead;
+                rightStickPosition.x = (fabs(rightStickPosition.x) * maxVal / max16) + rightDead;
             else if (rightStickPosition.x < 0)
-                rightStickPosition.x = -((abs(rightStickPosition.x) * maxVal / max16) + rightDead);
+                rightStickPosition.x = -((fabs(rightStickPosition.x) * maxVal / max16) + rightDead);
             else
                 rightStickPosition.x = 0;
             
             if (rightStickPosition.y > 0)
-                rightStickPosition.y = (abs(rightStickPosition.y) * maxVal / max16) + rightDead;
+                rightStickPosition.y = (fabs(rightStickPosition.y) * maxVal / max16) + rightDead;
             else if (rightStickPosition.y < 0)
-                rightStickPosition.y = -((abs(rightStickPosition.y) * maxVal / max16) + rightDead);
+                rightStickPosition.y = -((fabs(rightStickPosition.y) * maxVal / max16) + rightDead);
             else
                 rightStickPosition.y = 0;
         }
@@ -901,16 +901,16 @@
             CGFloat maxVal = max16 - leftDead;
             
             if (leftStickPosition.x > 0)
-                leftStickPosition.x = (abs(leftStickPosition.x) * maxVal / max16) + leftDead;
+                leftStickPosition.x = (fabs(leftStickPosition.x) * maxVal / max16) + leftDead;
             else if (leftStickPosition.x < 0)
-                leftStickPosition.x = -((abs(leftStickPosition.x) * maxVal / max16) + leftDead);
+                leftStickPosition.x = -((fabs(leftStickPosition.x) * maxVal / max16) + leftDead);
             else
                 leftStickPosition.x = 0;
             
             if (leftStickPosition.y > 0)
-                leftStickPosition.y = (abs(leftStickPosition.y) * maxVal / max16) + leftDead;
+                leftStickPosition.y = (fabs(leftStickPosition.y) * maxVal / max16) + leftDead;
             else if (leftStickPosition.y < 0)
-                leftStickPosition.y = -((abs(leftStickPosition.y) * maxVal / max16) + leftDead);
+                leftStickPosition.y = -((fabs(leftStickPosition.y) * maxVal / max16) + leftDead);
             else
                 leftStickPosition.y = 0;
         }

--- a/Pref360Control/en.lproj/Pref360ControlPref.xib
+++ b/Pref360Control/en.lproj/Pref360ControlPref.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="6254" systemVersion="14C109" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="7531" systemVersion="14C1514" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="6254"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="7531"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="Pref360ControlPref">
@@ -45,6 +45,7 @@
                 <outlet property="rightStickInvertY" destination="jdE-2i-HVe" id="dwF-3g-pwn"/>
                 <outlet property="rightStickInvertYAlt" destination="ASV-58-sZ1" id="ADg-YG-KGA"/>
                 <outlet property="rightTrigger" destination="BLH-hs-koP" id="G2s-bp-VgK"/>
+                <outlet property="rumbleOptions" destination="g1A-0k-b7Y" id="pYH-oe-IbE"/>
                 <outlet property="tabView" destination="hF4-J0-ko4" id="2mL-IX-fVY"/>
                 <outlet property="wholeController" destination="ILA-Sd-ahY" id="Mr1-K0-ZLS"/>
                 <outlet property="wholeControllerMapper" destination="jmX-SJ-ewe" id="VCe-Dg-aIB"/>
@@ -314,14 +315,6 @@
                                             <color key="borderColor" white="0.0" alpha="0.41999999999999998" colorSpace="calibratedWhite"/>
                                             <color key="fillColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                         </box>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="OTj-lL-cwP">
-                                            <rect key="frame" x="505" y="77" width="120" height="17"/>
-                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Xbox One Rumble:" id="eqi-tt-Lwa">
-                                                <font key="font" metaFont="system"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
                                         <popUpButton verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="g1A-0k-b7Y">
                                             <rect key="frame" x="497" y="45" width="137" height="26"/>
                                             <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="o1g-Uv-SAa">
@@ -339,6 +332,14 @@
                                                 <action selector="changeSetting:" target="-2" id="v1h-mW-iCb"/>
                                             </connections>
                                         </popUpButton>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="OTj-lL-cwP">
+                                            <rect key="frame" x="511" y="77" width="108" height="17"/>
+                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Rumble Options:" id="eqi-tt-Lwa">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
                                     </subviews>
                                     <constraints>
                                         <constraint firstItem="ILA-Sd-ahY" firstAttribute="top" secondItem="ZlQ-UU-WB8" secondAttribute="top" id="3fS-0G-1A4"/>
@@ -411,7 +412,7 @@
                                                         <rect key="frame" x="0.0" y="0.0" width="145" height="16"/>
                                                         <autoresizingMask key="autoresizingMask"/>
                                                         <size key="intercellSpacing" width="1" height="2"/>
-                                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                                        <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                                         <tableColumns>
                                                             <tableColumn identifier="binding" width="72" minWidth="40" maxWidth="1000" id="VVi-lm-klv">


### PR DESCRIPTION
I changed "Xone Rumble Options:" to "Rumble Options:" For non-Xbox One controllers, you are given the options "Default" and "None." If you are using an Xbox One controller, it also gives you "Triggers Only" and "Both." I've been working on my driver, so I can't test it, but all of the code is super straight forward.

Also I snuck in a new Xbox One controller. For some reason, my driver doesn't work with PowerA controllers, but this one might? I'd like to get an installer for this version once it is merged in order to test the additional controller support.

EDIT: Oh yeah, resolves #92 