### PR TITLE
Add Hori Real Arcade Pro Hayabusa for Xbox One

### DIFF
--- a/360Controller/Info.plist
+++ b/360Controller/Info.plist
@@ -431,6 +431,26 @@
 			<key>idVendor</key>
 			<integer>3853</integer>
 		</dict>
+		<key>HoriRAPHayabusaXboxOne</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>com.mice.driver.Xbox360Controller</string>
+			<key>IOCFPlugInTypes</key>
+			<dict>
+				<key>F4545CE5-BF5B-11D6-A4BB-0003933E3E3E</key>
+				<string>360Controller.kext/Contents/PlugIns/Feedback360.plugin</string>
+			</dict>
+			<key>IOClass</key>
+			<string>Xbox360Peripheral</string>
+			<key>IOKitDebug</key>
+			<integer>65535</integer>
+			<key>IOProviderClass</key>
+			<string>IOUSBDevice</string>
+			<key>idProduct</key>
+			<integer>62722</integer>
+			<key>idVendor</key>
+			<integer>7085</integer>
+		</dict>
 		<key>HoriRAPVXSA</key>
 		<dict>
 			<key>CFBundleIdentifier</key>


### PR DESCRIPTION
Just another Xbox One controller. I can't get third party controllers working with my driver, so I'd love to get a compiled version of this driver to see if it works with third party controllers.