### PR TITLE
Add New MS Xone Controller

### DIFF
--- a/360Controller/Info.plist
+++ b/360Controller/Info.plist
@@ -1051,7 +1051,7 @@
 			<key>idVendor</key>
 			<integer>1118</integer>
 		</dict>
-		<key>MicrosoftXboxOneController</key>
+		<key>MicrosoftXboxOneController2013</key>
 		<dict>
 			<key>CFBundleIdentifier</key>
 			<string>com.mice.driver.Xbox360Controller</string>
@@ -1068,6 +1068,26 @@
 			<string>IOUSBDevice</string>
 			<key>idProduct</key>
 			<integer>721</integer>
+			<key>idVendor</key>
+			<integer>1118</integer>
+		</dict>
+		<key>MicrosoftXboxOneController2015</key>
+		<dict>
+			<key>CFBundleIdentifier</key>
+			<string>com.mice.driver.Xbox360Controller</string>
+			<key>IOCFPlugInTypes</key>
+			<dict>
+				<key>F4545CE5-BF5B-11D6-A4BB-0003933E3E3E</key>
+				<string>360Controller.kext/Contents/PlugIns/Feedback360.plugin</string>
+			</dict>
+			<key>IOClass</key>
+			<string>Xbox360Peripheral</string>
+			<key>IOKitDebug</key>
+			<integer>65535</integer>
+			<key>IOProviderClass</key>
+			<string>IOUSBDevice</string>
+			<key>idProduct</key>
+			<integer>733</integer>
 			<key>idVendor</key>
 			<integer>1118</integer>
 		</dict>


### PR DESCRIPTION
Microsoft put out that new Xbox One controller with the 3.5mm jack. This adds the new IDs. The two are differentiated in the plist by year of release now.